### PR TITLE
remove unseen class for opened email to make it appear read, fix #18

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -192,6 +192,7 @@ var Mail = {
 							var mailBody = summaryRow.find('.mail_message');
 							mailBody.html(html);
 							mailBody.slideDown();
+							mailBody.parent().removeClass('unseen');
 						});
 
 						// Set current Message as active


### PR DESCRIPTION
Fixes https://github.com/owncloud/mail/issues/18 – simply removes the »unseen« class for the message which is opened. That way it also appears directly as if it has been read.

@DeepDiver1975 is the code ok like that or is there a better way to do it?
