### PR TITLE
Get messageId from params instead of a getting a null method parameter

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -74,16 +74,16 @@ class MessagesController extends Controller
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 *
-	 * @param int $id
+	 * 
 	 * @return JSONResponse
 	 */
-	public function show($id)
+	public function show()
 	{
 		$accountId = $this->params('accountId');
 		$folderId = $this->params('folderId');
 		$mailBox = $this->getFolder();
-
+		$id = $this->params('messageId');
+		
 		$m = $mailBox->getMessage($id);
 		$json = $m->as_array();
 		$json['senderImage'] = $this->contactsIntegration->getPhoto($m->getFromEmail());


### PR DESCRIPTION
On my server, the $id parameter passed to show() seemed to always be null, so I couldn't open any email message. Fetching the messageId from the url parameters seem to fix it.
