### PR TITLE
grey out previous replies, ref #89

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -361,6 +361,12 @@ var Mail = {
 								});
 								// Expand height again after rendering to account for new size
 								$(this).height( $(this).contents().find('html').height() + 20);
+								// Grey out previous replies
+								$(this).contents().find('blockquote').css({
+									'-ms-filter': '"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"',
+									'filter': 'alpha(opacity=50)',
+									'opacity': '.5'
+								});
 								// Remove spinner when loading finished
 								$('iframe').parent().removeClass('icon-loading');
 							});


### PR DESCRIPTION
Works on HTML mails only for now. Detecting the replies in plain-text only mails (parts which start with `>`) is tracked in #89.
