### PR TITLE
get user email from settings, fix #128

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -186,7 +186,8 @@
 
 			<p class="grouptop">
 				<input type="email" name="mail-address" id="mail-address"
-					   placeholder="<?php p($l->t('Mail Address')); ?>" value=""
+					   placeholder="<?php p($l->t('Mail Address')); ?>"
+					   value="<?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?>"
 					   autofocus autocomplete="off" required/>
 				<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
 			</p>

--- a/templates/no-accounts.php
+++ b/templates/no-accounts.php
@@ -4,7 +4,8 @@
 
 		<p class="grouptop">
 			<input type="email" name="mail-address" id="mail-address"
-				placeholder="<?php p($l->t('Mail Address')); ?>" value=""
+				placeholder="<?php p($l->t('Mail Address')); ?>"
+				value="<?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?>"
 				autofocus autocomplete="off" required/>
 			<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
 		</p>


### PR DESCRIPTION
Get the email from the personal settings of the user to prefill the »Email address« field with it. @MorrisJobke @DeepDiver1975 @tomneedham 

Fix #128 
