### PR TITLE
Display loaded  account in the select

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -43,6 +43,7 @@ var Mail = {
 				},
 
 				loadAccount: function(id) {
+					$('select.mail_account').val(id);
 					if (id === 'new') {
 						Mail.UI.addAccount();
 					} else {


### PR DESCRIPTION
Make sure the select displays the correct account if loaded through the new routes
