### PR TITLE
Sort mailboxes, including special use folders

### DIFF
--- a/lib/account.php
+++ b/lib/account.php
@@ -254,9 +254,9 @@ class Account {
 					);
 					return $specialRolesOrder[$roleA] - $specialRolesOrder[$roleB];
 				}
-			} elseif ($roleA === null && $roleB === null) {
-				return strcasecmp($a->getDisplayName(), $b->getDisplayName());
-			}
+			} 
+			// we get here if $roleA === null && $roleB === null
+			return strcasecmp($a->getDisplayName(), $b->getDisplayName());
 		});
 
 		$this->mailboxes = $mailboxes;

--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -265,9 +265,5 @@ class Mailbox {
 		}
 		$this->conn->store($this->folderId, $options);
 	}
-
-	private function isTrash() {
-		return $this->getSpecialRole() === 'trash';
-	}
 }
 


### PR DESCRIPTION
Still on my quest to fix #177, using @DeepDiver1975 's #202 

Mailboxes are sorted alphabetically, with special folders at the top in the order proposed by @jancborchardt 

Because some clients don't follow the server's special use flags (and some servers don't provide the flags), the special use role is also guessed based on the folder's name.

For situations where we want to get only one folder (for example, "which is the 'Sent' folder?"), the folder with the most messages in it is considered the best candidate.

In this code, the special use roles are also sent back to the client in the json array, but it's not used there yet.
