### PR TITLE
Show the "add account" screen if no account is already configured

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -91,10 +91,14 @@ var Mail = {
 				data:{},
 				type:'GET',
 				success:function (jsondata) {
-						Mail.State.accounts = jsondata;
-						_.each(Mail.State.accounts, function(a) {
-							Mail.UI.loadFoldersForAccount(a.accountId);
-						});
+						if (jsondata.length === 0) {
+							Mail.UI.addAccount();
+						} else {
+							Mail.State.accounts = jsondata;
+							_.each(Mail.State.accounts, function(a) {
+								Mail.UI.loadFoldersForAccount(a.accountId);
+							});
+						}
 					},
 				error: function() {
 					Mail.UI.showError(t('mail', 'Error while loading the accounts.'));


### PR DESCRIPTION
Because the account switcher (and then the router from within mail.js) was removed,  the new account configuration screen was not shown if an empty set of account was found on the server
