### PR TITLE
fix width of compose input fields (for mailto links)

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -448,8 +448,9 @@ button.control {
 
 
 
-/* compose */
+/* compose (handling mailto links) */
 
-.compose #new-message {
-	left: 25%;
+.compose {
+	width: 60%;
+	margin: 0 auto;
 }


### PR DESCRIPTION
Currently when using a mailto link (like [mailto:test@example.com](mailto:test@example.com)), the input fields and textarea uses the full width which looks weird on larger screens. This restricts it to use 60%.

On mobile / smaller screens, the inputs and textarea will still use the full width as before, and as designed.

Please review @zinks- @PoPoutdoor @Gomez 
