### PR TITLE
hide cc toggle for replies when cc is already expanded and prefilled

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -125,7 +125,10 @@
 
 		<div class="reply-message-fields">
 			<a href="#" id="reply-message-cc-bcc-toggle"
-			   class="transparency"><?php p($l->t('+ cc')); ?></a>
+				{{#if replyCcList}}
+				class="hidden"
+				{{/if}}
+				class="transparency"><?php p($l->t('+ cc')); ?></a>
 
 			<input type="text" name="to" id="to" class="recipient-autocomplete"
 				   placeholder="<?php p($l->t('Recipient')); ?>"


### PR DESCRIPTION
Previously it was possible to accidentally click it, which hid both the cc field and the toggle (so it could not be displayed again).

Please review @zinks- @DeepDiver1975 @Gomez @PoPoutdoor
