### PR TITLE
properly center 'check mail' and 'load more' buttons

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -122,14 +122,10 @@ button.control {
 	overflow-x: hidden;
 	overflow-y: auto;
 }
-#load-new-mail-messages {
-	display: none;
-	margin: 10px 35%;
-	padding: 10px 10px 6px;
-}
+#load-new-mail-messages,
 #load-more-mail-messages {
 	display: none;
-	margin: 10px 35%;
+	margin: 10px auto;
 	padding: 10px 10px 6px;
 }
 /* TODO: put this in core icons.css as general rule for buttons with icons */

--- a/js/mail.js
+++ b/js/mail.js
@@ -220,9 +220,9 @@ var Mail = {
 						// Add messages
 						Mail.UI.addMessages(jsondata);
 						$('#mail_messages').removeClass('icon-loading');
-						$('#load-new-mail-messages').fadeIn();
+						$('#load-new-mail-messages').fadeIn().css('display','block');
 						$('#load-new-mail-messages').prop('disabled', false);
-						$('#load-more-mail-messages').fadeIn();
+						$('#load-more-mail-messages').fadeIn().css('display','block');
 
 						Mail.State.currentAccountId = accountId;
 						Mail.State.currentFolderId = folderId;


### PR DESCRIPTION
Previously the buttons weren’t really centered but just offset by a hardcoded percentage. This looked strange with different translations and when you clicked the buttons.

Please review @DeepDiver1975 @zinks- @Gomez @PoPoutdoor
