### PR TITLE
Show inbox if empty + handle empty folders

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -94,6 +94,11 @@ button.control {
 	display: block;
 }
 
+#emptycontent {
+	position: static;
+	margin-top: 2em;
+}
+
 .mail_account_email {
 	opacity: .5;
 	padding: 20px 0 10px 12px;

--- a/js/mail.js
+++ b/js/mail.js
@@ -210,6 +210,7 @@ var Mail = {
 			$('#mail_messages').addClass('icon-loading');
 			$('#load-new-mail-messages').hide();
 			$('#load-more-mail-messages').hide();
+			$('#emptycontent').hide();
 
 			$.ajax(
 				OC.generateUrl('apps/mail/accounts/{accountId}/folders/{folderId}/messages',
@@ -217,21 +218,23 @@ var Mail = {
 					data: {},
 					type:'GET',
 					success: function (jsondata) {
-						// Add messages
-						Mail.UI.addMessages(jsondata);
-						$('#mail_messages').removeClass('icon-loading');
-						$('#load-new-mail-messages').fadeIn().css('display','block');
-						$('#load-new-mail-messages').prop('disabled', false);
-						$('#load-more-mail-messages').fadeIn().css('display','block');
 
 						Mail.State.currentAccountId = accountId;
 						Mail.State.currentFolderId = folderId;
 						Mail.UI.setMessageActive(null);
-
+						$('#mail_messages').removeClass('icon-loading');
 						if(jsondata.length > 0) {
+							Mail.UI.addMessages(jsondata);
 							var messageId = jsondata[0].id;
 							Mail.UI.openMessage(messageId);
+							$('#load-more-mail-messages').fadeIn().css('display','block');
+						} else {
+							$('#emptycontent').show();
+							$('#mail-message').removeClass('icon-loading');
 						}
+						$('#load-new-mail-messages').fadeIn().css('display','block');
+						$('#load-new-mail-messages').prop('disabled', false);
+
 					},
 					error: function() {
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -206,7 +206,8 @@
 </script>
 <script id="message-list-template" type="text/x-handlebars-template">
 	<input type="button" id="load-new-mail-messages" value="<?php p($l->t('Check mail …')); ?>">
-		<div id="mail-message-list"></div>
+	<div id="emptycontent" style="display: none;"><?php p($l->t('No mail in this folder!')); ?></div>
+	<div id="mail-message-list"></div>
 	<input type="button" id="load-more-mail-messages" value="<?php p($l->t('Load more …')); ?>">
 </script>
 <div id="app">
@@ -223,7 +224,6 @@
 		</div>
 	</div>
 	<div id="app-content">
-
 		<div id="mail_messages" class="icon-loading">
 		</div>
 


### PR DESCRIPTION
Fix #200 
This code makes sure the Inbox and the 'All Mail' folders are always visible in the navigation even if they are empty.

It also displays a 'No mail in this folder!' message when the folder is loaded. i used a slightly tweaked version of core's #emptycontent style for consistency.

@jancborchardt @DeepDiver1975 @Popoutdoor please review!
