### PR TITLE
put 'from' and account name in mailto handler

### DIFF
--- a/templates/compose.php
+++ b/templates/compose.php
@@ -15,7 +15,7 @@
 	<div id="new-message">
 		<select class="mail_account">
 			{{#each aliases}}
-			<option value="{{accountId}}">{{emailAddress}}</option>
+			<option value="{{accountId}}"><?php p($l->t('from')); ?> {{name}} &lt;{{emailAddress}}&gt;</option>
 			{{/each}}
 		</select>
 


### PR DESCRIPTION
Must have got lost during a merge. This makes it how it’s supposed to be, displaying your name in the mailto handler window. Test with [mailto:test@example.com](mailto:test@example.com)

Please test @DeepDiver1975 @zinks- @Gomez @PoPoutdoor
