### PR TITLE
Guess special use role for sub folders too

### DIFF
--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -243,7 +243,7 @@ class Mailbox {
 		);
 		
 		$lowercaseExplode = explode($this->delimiter, $this->getFolderId(), 2);
-		$lowercaseId = strtolower(reset($lowercaseExplode));
+		$lowercaseId = strtolower(array_pop($lowercaseExplode));
 		$result = null;
 		foreach ($specialFoldersDict as $specialRole => $specialNames) {
 			if (in_array($lowercaseId, $specialNames)) {


### PR DESCRIPTION
Should fix #312 , by correctly guessing the special use of subfolders: 
now "INBOX/Sent" or similar will be found as the "sent mail" folder.
