### PR TITLE
add transparency for mail sender to focus on subject

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -212,6 +212,7 @@ button.control {
 	width: 55%;
 	margin-left: 37px;
 	padding-bottom: 0;
+	opacity: .5;
 }
 
 .mail_message_summary_subject {


### PR DESCRIPTION
Please review @DeepDiver1975 @Gomez @zinks- @PoPoutdoor 

Otherwise the list of mails is difficult to scan because both sender name and subject has the focus.
Since sender already gets a big image for identification, we can put the text emphasis on the subject.
