### PR TITLE
Remove wrapping div from backbone view for folders list

### DIFF
--- a/js/views/folder.js
+++ b/js/views/folder.js
@@ -26,6 +26,16 @@ views.Folder = Backbone.Marionette.ItemView.extend({
 		var folderId = $(e.currentTarget).parent().data('folder_id');
 		var noSelect = $(e.currentTarget).parent().data('no_select');
 		Mail.UI.loadMessages(accountId, folderId, noSelect);
+	},
+
+	onRender: function() {
+		// Get rid of that pesky wrapping-div.
+		// Assumes 1 child element present in template.
+		this.$el = this.$el.children();
+		// Unwrap the element to prevent infinitely
+		// nesting elements during re-render.
+		this.$el.unwrap();
+		this.setElement(this.$el);
 	}
 });
 


### PR DESCRIPTION
Fixes a minor issue stumbled upon while investigating #341 
(does not fix that issue though)
- Before :
  ![screenshot from 2014-09-21 23 46 52](https://cloud.githubusercontent.com/assets/8377141/4361993/6159c73a-4289-11e4-8515-9635fd6bb0ba.png)
- After :
  ![after](https://cloud.githubusercontent.com/assets/8377141/4361990/5f0be206-4289-11e4-99ae-fcc9077e6f6c.png)

thanks @DeepDiver1975 for the instructions
