### PR TITLE
REmove wrapping div in folder list (revised)

### DIFF
--- a/js/views/folder.js
+++ b/js/views/folder.js
@@ -8,7 +8,7 @@ views.Folder = Backbone.Marionette.ItemView.extend({
 
 	events: {
 		"click .collapse" : "collapseFolder",
-		"click li a" : "loadMessages"
+		"click .folder" : "loadMessages"
 	},
 
 	initialize: function(options) {
@@ -26,6 +26,16 @@ views.Folder = Backbone.Marionette.ItemView.extend({
 		var folderId = $(e.currentTarget).parent().data('folder_id');
 		var noSelect = $(e.currentTarget).parent().data('no_select');
 		Mail.UI.loadMessages(accountId, folderId, noSelect);
+	},
+
+	onRender: function() {
+		// Get rid of that pesky wrapping-div.
+		// Assumes 1 child element present in template.
+		this.$el = this.$el.children();
+		// Unwrap the element to prevent infinitely
+		// nesting elements during re-render.
+		this.$el.unwrap();
+		this.setElement(this.$el);
 	}
 });
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -7,7 +7,7 @@
 		{{#if open}} open{{/if}}
 		">
 		{{#if folders}}<button class="collapse"></button>{{/if}}
-		<a{{#if specialRole}} class="icon-{{specialRole}}"{{/if}}>
+		<a class="folder {{#if specialRole}} icon-{{specialRole}}{{/if}}">
 			{{name}}
 			{{#if unseen}}
 			<span class="utils">{{unseen}}</span>
@@ -20,7 +20,7 @@
 		{{#if unseen}}unread{{/if}}
 		{{#if specialRole}} special-{{specialRole}}{{/if}}
 		">
-				<a{{#if specialRole}} class="icon-{{specialRole}}"{{/if}}>
+				<a class="folder {{#if specialRole}} icon-{{specialRole}}{{/if}}">
 					{{name}}
 					{{#if unseen}}
 					<span class="utils">{{unseen}}</span>


### PR DESCRIPTION
Changed the click handler selector to make it work again on top folders when we remove the wrapping div

I have no idea why `.folder` works and `li a` doesn't !?

@DeepDiver1975 Can you test, also @jancborchardt @PoPoutdoor 
