### PR TITLE
Load messages of newly created account

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -584,7 +584,7 @@ $(document).ready(function () {
 			type:'POST',
 			success:function (data) {
 				var newAccountId = data.data.id;
-				Mail.UI.loadFoldersForAccount(newAccountId);
+				Mail.UI.loadFoldersForAccount(newAccountId, newAccountId);
 			},
 			error: function(jqXHR, textStatus, errorThrown){
 				var error = errorThrown || textStatus || t('mail', 'Unknown error');


### PR DESCRIPTION
Fix for #367 
See also https://github.com/owncloud/mail/pull/333#issuecomment-56743291

I double-checked and in master it never loads the messages for any newly created account unless I click a folder.
Can you @DeepDiver1975 @PoPoutdoor @jancborchardt @Gomez thos issue ?

There was no request for /messages, so I figured the issue was in the javascript.
The second parameter of `loadFoldersForAccount` contains the id of the account for which messages should be loaded after the folder listing has been retreived.

What do you think ? 
