### PR TITLE
Fix folder tree after translations

### DIFF
--- a/lib/controller/folderscontroller.php
+++ b/lib/controller/folderscontroller.php
@@ -63,9 +63,9 @@ class FoldersController extends Controller
 			if (is_null($folder['parent'])) {
 				continue;
 			}
-			$parentName = $folder['parent'];
+			$parentId = $folder['parent'];
 			foreach($folders as &$parent) {
-				if($parent['name'] === $parentName) {
+				if($parent['id'] === $parentId) {
 					if (!isset($parent['folders'])) {
 						$parent['folders'] = array();
 					}

--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -153,9 +153,6 @@ class Mailbox {
 		$parts = explode($this->delimiter, $folderId, 2);
 
 		if (count($parts) > 1) {
-			if (strtolower($parts[0]) === 'inbox') {
-				return ucwords(strtolower($parts[0]));
-			}
 			return $parts[0];
 		}
 
@@ -186,9 +183,11 @@ class Mailbox {
 			$unseen = ($specialRole === 'trash') ? 0 : $status['unseen'];
 			$isEmpty = ($total === 0);
 			$noSelect = in_array('\\noselect', $this->attributes);
+			$parentId = $this->getParent();
+			$parentId = ($parentId !== null) ? base64_encode($parentId) : null;
 			return array(
 				'id' => base64_encode($this->getFolderId()),
-				'parent' => $this->getParent(),
+				'parent' => $parentId,
 				'name' => $displayName,
 				'specialRole' => $specialRole,
 				'unseen' => $unseen,


### PR DESCRIPTION
The translation process changes the names of the folders, thus subfolders cannot find their parent anymore.
this fix uses only folder IDs, which do not change.

Please review @DeepDiver1975 @jancborchardt @PoPoutdoor 
