### PR TITLE
fix star being hard to click because of email sender overlap

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -382,6 +382,7 @@ button.control {
 	position: absolute;
 	top: 0;
 	left: 31px;
+	z-index: 10;
 }
 /* only show star on hover of row */
 .star.icon-star {


### PR DESCRIPTION
Brings the star to the top a bit. Previously it was overlapped by the element of the email sender.

Please review @DeepDiver1975 @zinks- @PoPoutdoor 
