### PR TITLE
Show spinner only for attachments being saved

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -352,7 +352,11 @@ var Mail = {
 				t('mail', 'Choose a folder to store the attachment in'),
 				function (path) {
 					// Loading feedback
-					$('.attachment-save-to-cloud')
+					var saveToFilesBtnSelector = '.attachment-save-to-cloud';
+					if (typeof attachmentId !== "undefined") {
+						saveToFilesBtnSelector = 'li[data-attachment-id="'+attachmentId+'"] '+saveToFilesBtnSelector;
+					}
+					$(saveToFilesBtnSelector)
 						.removeClass('icon-upload')
 						.addClass('icon-loading-small')
 						.prop('disabled', true);


### PR DESCRIPTION
Fix #305 "If a mail has two attachments and i wanna save one - two save spinner are shown"

Now the spinner is shown only in the button for the right attachment (using attachmentId).
All spinners shown if we're saving all files at once.
