### PR TITLE
properly convert mail content to utf-8

### DIFF
--- a/lib/message.php
+++ b/lib/message.php
@@ -438,7 +438,10 @@ class Message {
 		// DECODE DATA
 		$data = $this->queryBodyPart($partNo);
 		$p->setContents($data);
-		return $p->getContents();
+		$data = $p->getContents();
+
+		$data = iconv($p->getCharset(), 'utf-8', $data);
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
for testing: open a mail which has a non utf8 content type - e.g. @MorrisJobke 's mail on the owncloud devel mailing list with the subject 'Re: [owncloud-devel] Is it possible to serve the minimized versions of js/css in OC7.x?'

This one has the content type:

```
Content-Type: text/plain; charset="windows-1252"; Format="flowed"
```
