### PR TITLE
Dropdown selection added for IMAP & SMTP security config

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -512,6 +512,30 @@ $(document).ready(function () {
 			}
 		});
 	});
+	
+	// set standard port for the selected IMAP & SMTP security
+	
+	$(document).on('change', '#mail-imap-sslmode', function () {
+		var imapDefaultPort = 143;
+		var imapDefaultSecurePort = 993;
+
+		if ($(this).val() == "none") {
+			$('#mail-imap-port').val(imapDefaultPort);		
+		} else {
+			$('#mail-imap-port').val(imapDefaultSecurePort);		
+		}
+	});
+
+	$(document).on('change', '#mail-smtp-sslmode', function () {
+		var smtpDefaultPort = 25;
+		var smtpDefaultSecurePort = 465;
+
+		if ($(this).val() == "none") {
+			$('#mail-smtp-port').val(smtpDefaultPort);		
+		} else  {
+			$('#mail-smtp-port').val(smtpDefaultSecurePort);				
+		}
+	});
 
 	// toggle for advanced account configuration
 	$(document).on('click', '#mail-setup-manual-toggle', function () {

--- a/templates/index.php
+++ b/templates/index.php
@@ -283,16 +283,18 @@
 					<label for="mail-imap-host" class="infield"><?php p($l->t('IMAP Host')); ?></label>
 				</p>
 				<p class="groupmiddle">
+						<label for="mail-imap-sslmode"><?php p($l->t('IMAP security')); ?></label>
+						<select name="mail-imap-sslmode" id="mail-imap-sslmode" title="<?php p($l->t('IMAP security')); ?>">
+							<option value="none"><?php p($l->t('none')); ?></option>
+							<option value="ssl"><?php p($l->t('ssl')); ?></option>
+							<option value="tls"><?php p($l->t('tls')); ?></option>
+						</select>
+				</p>
+				<p class="groupmiddle"> 
 					<input type="email" name="mail-imap-port" id="mail-imap-port"
 						placeholder="<?php p($l->t('IMAP Port')); ?>"
-						value="" />
+						value="143" />
 					<label for="mail-imap-port" class="infield"><?php p($l->t('IMAP Port')); ?></label>
-				</p>
-				<p class="groupmiddle">
-					<input type="email" name="mail-imap-sslmode" id="mail-imap-sslmode"
-						placeholder="<?php p($l->t('IMAP SSL mode')); ?>"
-						value="" />
-					<label for="mail-imap-sslmode" class="infield"><?php p($l->t('IMAP SSL mode')); ?></label>
 				</p>
 				<p class="groupmiddle">
 					<input type="email" name="mail-imap-user" id="mail-imap-user"
@@ -314,16 +316,18 @@
 					<label for="mail-smtp-host" class="infield"><?php p($l->t('SMTP Host')); ?></label>
 				</p>
 				<p class="groupmiddle">
-					<input type="email" name="mail-smtp-port" id="mail-smtp-port"
-						placeholder="<?php p($l->t('SMTP Port')); ?>"
-						value="" />
-					<label for="mail-smtp-port" class="infield"><?php p($l->t('SMTP Port')); ?></label>
+					<label for="mail-smtp-sslmode"><?php p($l->t('SMTP security')); ?></label>
+					<select name="mail-smtp-sslmode" id="mail-smtp-sslmode" title="<?php p($l->t('SMTP security')); ?>">
+						<option value="none"><?php p($l->t('none')); ?></option>
+						<option value="ssl"><?php p($l->t('ssl')); ?></option>
+						<option value="tls"><?php p($l->t('tls')); ?></option>
+					</select>
 				</p>
 				<p class="groupmiddle">
-					<input type="email" name="mail-smtp-sslmode" id="mail-smtp-sslmode"
-						placeholder="<?php p($l->t('SMTP SSL mode')); ?>"
-						value="" />
-					<label for="mail-smtp-sslmode" class="infield"><?php p($l->t('SMTP SSL mode')); ?></label>
+					<input type="email" name="mail-smtp-port" id="mail-smtp-port"
+						placeholder="<?php p($l->t('SMTP Port')); ?>"
+						value="25" />
+					<label for="mail-smtp-port" class="infield"><?php p($l->t('SMTP Port (default 25, ssl 465)')); ?></label>
 				</p>
 				<p class="groupmiddle">
 					<input type="email" name="mail-smtp-user" id="mail-smtp-user"


### PR DESCRIPTION
(attempt No. X)
As discussed by the main developers of the master branch, two dropdown
boxes have been added with subsequent prefilling of the port fields.

IMAP security "none","ssl","tls"
-> IMAP port  "143","993"

SMTP security "none","ssl","tls"
-> SMTP port "25","465"

There are new challenges by adding these boxes - it breaks the original
"design". But at least the functionality is given.