### PR TITLE
Restructured app-navigation to show the last folder in the list

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -121,7 +121,15 @@ button.control {
 	opacity: .3;
 }
 
+#app-navigation ul {
+	overflow-x: hidden;
+}
+
 #app-navigation ul ul {
+	display: block;
+}
+
+#app-navigation ul ul ul {
 	display: none;
 }
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -228,9 +228,15 @@
 </script>
 <div id="app">
 	<div id="app-navigation" class="icon-loading">
-		<input type="button" id="mail_new_message" class="icon-add"
-			value="<?php p($l->t('New Message')); ?>" style="display: none">
-		<div id="folders"></div>
+		<ul>
+			<li>
+			<input type="button" id="mail_new_message" class="icon-add"
+				value="<?php p($l->t('New Message')); ?>" style="display: none">
+			</li>
+			<li>
+				<div id="folders"></div>
+			</li>
+		</ul>
 		<div id="app-settings">
 			<div id="app-settings-header">
 				<button class="settings-button"


### PR DESCRIPTION
Fixes #341 
The padding that should have prevented the settings bar from hiding the last folder in the list didn't seem to apply because of the difference in structure between our app-navigation and the one that the css was made for (for example the app-navigation from the Files app)

I restructured our app-navigation to be like the one of the Files app, and now I can finally see and click my last folder!

@PoPoutdoor I know you had this issue as well, can you test ? thx
