### PR TITLE
show 'New Message' button on emtpy accounts

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -236,6 +236,11 @@ var Mail = {
 							Mail.State.currentFolderId = folderId;
 							Mail.UI.setMessageActive(null);
 							$('#mail_messages').removeClass('icon-loading');
+							
+							// Fade out the message composer
+							$('#mail_new_message').prop('disabled', false);
+							$('#new-message').hide();
+			
 							if(jsondata.length > 0) {
 								Mail.UI.addMessages(jsondata);
 								var messageId = jsondata[0].id;
@@ -320,10 +325,6 @@ var Mail = {
 		},
 
 		openMessage:function (messageId) {
-			// Fade out the message composer
-			$('#mail_new_message').prop('disabled', false);
-			$('#new-message').hide();
-
 			// Do not reload email when clicking same again
 			if(Mail.State.currentMessageId === messageId) {
 				return;


### PR DESCRIPTION
As described [here](https://github.com/owncloud/mail/issues/427), 'New Messages' has some strange behavior on emtpy accounts:
- it is visible and active when the app loads
- it gets disabled when you click it
- when a user clicks on a folder again, the button does not become active again

fixes #427