### PR TITLE
autoconfig logging added

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -56,7 +56,8 @@ class Application extends App {
 				$c->query('UserId'),
 				$c->getServer()->getUserFolder(),
 				$c->query('ContactsIntegration'),
-				$c->query('AutoConfig')
+				$c->query('AutoConfig'),
+				$c->query('Logger')
 			);
 		});
 


### PR DESCRIPTION
looking at issue #330, I found out that the error message ```'Creating account failed: '``` was passed to translation with the exception message, resulting in an empty message string in the json response.

I also added some logging for further issues with autconfig.