### PR TITLE
decrease unread counter

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -105,8 +105,8 @@ var Mail = {
 			});
 			Mail.State.folderView.render();
 
-			Mail.State.folderView.listenTo(Mail.State.messageView, 'change:flags',
-				Mail.State.folderView.changeMessageFlags);
+			Mail.State.folderView.listenTo(Mail.State.messageView, 'change:unseen',
+				Mail.State.folderView.changeUnseen);
 
 			$.ajax(OC.generateUrl('apps/mail/accounts'), {
 				data:{},

--- a/js/views/folder.js
+++ b/js/views/folder.js
@@ -67,13 +67,8 @@ views.Folders = Backbone.Marionette.CollectionView.extend({
 	initialize: function() {
 		this.collection = new models.AccountList();
 	},
-
-	changeMessageFlags: function(model) {
-		var unseen = model.get('flags').get('unseen');
-		var prevUnseen = model._previousAttributes.flags.get('unseen');
-		if (unseen === prevUnseen) {
-			return;
-		}
+	
+	changeUnseen: function(model, unseen) {
 		// TODO: currentFolderId and currentAccountId should be an attribute of this view
 		var activeAccount = Mail.State.currentAccountId;
 		var activeFolder = Mail.State.currentFolderId;
@@ -82,7 +77,9 @@ views.Folders = Backbone.Marionette.CollectionView.extend({
 		if (unseen) {
 			activeFolder.set('unseen', activeFolder.get('unseen') + 1);
 		} else {
-			activeFolder.set('unseen', activeFolder.get('unseen') - 1);
+			if (activeFolder.get('unseen') > 0) {
+				activeFolder.set('unseen', activeFolder.get('unseen') - 1);
+			}
 		}
 	}
 

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -137,7 +137,11 @@ views.Messages = Backbone.Marionette.CompositeView.extend({
 	},
 
 	changeFlags: function(model) {
-		this.trigger('change:flags', model);
+		var unseen = model.get('flags').get('unseen');
+		var prevUnseen = model._previousAttributes.flags.get('unseen');
+		if (unseen === prevUnseen) {
+			this.trigger('change:unseen', model, unseen);
+		}
 	},
 
 	setMessageFlag: function(messageId, flag, val) {


### PR DESCRIPTION
changeMessageFlags did not have the old attribute state anymore, so the evaluation logic was moved to the changeFlags listener function

With this change, the unread counter seems to work again. However, I'm sure there's possibly a better solution since I am no JavaScript expert ;-)

fixes #246