### PR TITLE
remove double escaping

### DIFF
--- a/js/views/sendmail.js
+++ b/js/views/sendmail.js
@@ -1,4 +1,4 @@
-/* global Backbone, Handlebars, models, escapeHTML */
+/* global Backbone, Handlebars, models */
 
 var views = views || {};
 
@@ -60,7 +60,7 @@ views.SendMail = Backbone.View.extend({
 		$.ajax({
 			url:OC.generateUrl('/apps/mail/accounts/{accountId}/send', {accountId: this.currentAccountId}),
 			beforeSend:function () {
-				OC.msg.startAction('#new-message-msg', {});
+				OC.msg.startAction('#new-message-msg', "");
 			},
 			type: 'POST',
 			data:{
@@ -75,7 +75,7 @@ views.SendMail = Backbone.View.extend({
 				OC.msg.finishedAction('#new-message-msg', {
 					status: 'success',
 					data: {
-						message: t('mail', 'Message sent to {Receiver}', {Receiver: escapeHTML(to.val())})
+						message: t('mail', 'Message sent to {Receiver}', {Receiver: to.val()})
 					}
 				});
 


### PR DESCRIPTION
as described in #448, the message shown when mails are sent was double escaped.
To prevent the `[object Object]` output, I changed `{}` to an empty string - does this line make any sense at all? should the app print something about sending the mail?

This is only a fix for sending new mails. If you reply to a mail the `to` value is extracted from the input field, which is already escaped, so the double escaping occurs again.

Does anybody know a good solution to fix replying too? @jancborchardt @LukasReschke 
