### PR TITLE
directly change star state in the interface for quick feedback

### DIFF
--- a/js/views/message.js
+++ b/js/views/message.js
@@ -43,10 +43,17 @@ views.Message = Backbone.Marionette.ItemView.extend({
 		var messageId = this.model.id;
 		var starred = this.model.get('flags').get('flagged');
 		var thisModel = this.model;
-		this.ui.star
-			.removeClass('icon-starred')
-			.removeClass('icon-star')
-			.addClass('icon-loading-small');
+
+		// directly change star state in the interface for quick feedback
+		if(starred) {
+			this.ui.star
+				.removeClass('icon-starred')
+				.addClass('icon-star');
+		} else {
+			this.ui.star
+				.removeClass('icon-star')
+				.addClass('icon-starred');
+		}
 
 		$.ajax(
 			OC.generateUrl('apps/mail/accounts/{accountId}/folders/{folderId}/messages/{messageId}/toggleStar',


### PR DESCRIPTION
Currently we show a little loading spinner while the message is being starred. This results in perceived slowness of the app.

So instead, we just lie and change the status directly. In the off-case there is an error it will just change back.

Please review @DeepDiver1975 @wurstchristoph @Gomez @zinks- @LukasReschke 