### PR TITLE
reduce message list width in favor of message detail view

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -187,7 +187,7 @@ button.control {
 
 #mail_messages {
 	padding-bottom: 250px;
-	width: 35%;
+	width: 30%;
 	height: 100%;
 	overflow-x: hidden;
 	overflow-y: auto;
@@ -500,7 +500,7 @@ button.control {
 	position: absolute;
 	top: 0;
 	right: 0;
-	width: 65%;
+	width: 70%;
 	height: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;


### PR DESCRIPTION
Instead of 35% (message list) and 65% (message detail view) width, it’s now 30% and 70%. This gives more space to the actual emails.

Please review @DeepDiver1975 @wurstchristoph 