### PR TITLE
empty cc and bcc fields on send as well

### DIFF
--- a/js/views/sendmail.js
+++ b/js/views/sendmail.js
@@ -87,6 +87,8 @@ views.SendMail = Backbone.View.extend({
 				}
 				$('#mail_new_message').prop('disabled', false);
 				$('#to').val('');
+				$('#cc').val('');
+				$('#bcc').val('');
 				$('#subject').val('');
 				$('#new-message-body').val('');
 				self.attachments.reset();


### PR DESCRIPTION
Before we didn’t clear them visually like we did with the other fields. Please review @DeepDiver1975 @wurstchristoph 