### PR TITLE
use correct capitalization for 'Re:' prefix, prevent stacking

### DIFF
--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -60,7 +60,7 @@ class AccountsController extends Controller
 	 * @var \OCP\Files\Folder
 	 */
 	private $userFolder;
-	
+
 	/**
 	 *
 	 * @var Logger
@@ -231,7 +231,7 @@ class AccountsController extends Controller
 			$message = $mailbox->getMessage($messageId);
 
 			if (is_null($subject)) {
-				$headers['Subject'] = "RE: " . $message->getSubject();
+				$headers['Subject'] = 'Re: ' . $message->getSubject();
 			}
 			$headers['In-Reply-To'] = $message->getMessageId();
 			if (is_null($to)) {

--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -231,7 +231,12 @@ class AccountsController extends Controller
 			$message = $mailbox->getMessage($messageId);
 
 			if (is_null($subject)) {
-				$headers['Subject'] = 'Re: ' . $message->getSubject();
+				// prevent 'Re: Re:' stacking
+				if(strcasecmp(substr($message->getSubject(), 0, 4), 'Re: ') === 0) {
+					$headers['Subject'] = $message->getSubject();
+				} else {
+					$headers['Subject'] = 'Re: ' . $message->getSubject();
+				}
 			}
 			$headers['In-Reply-To'] = $message->getMessageId();
 			if (is_null($to)) {


### PR DESCRIPTION
Changing from the strange-looking capitalized »RE:« prefix to the more commonly used (and less screamy/technical ;) »Re:«.

Please review @DeepDiver1975 @wurstchristoph @zinks- 