### PR TITLE
Remove shading of date

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -556,17 +556,17 @@ $(document).ready(function () {
 			}
 		});
 	});
-	
+
 	// set standard port for the selected IMAP & SMTP security
-	
+
 	$(document).on('change', '#mail-imap-sslmode', function () {
 		var imapDefaultPort = 143;
 		var imapDefaultSecurePort = 993;
 
 		if ($(this).val() == "none") {
-			$('#mail-imap-port').val(imapDefaultPort);		
+			$('#mail-imap-port').val(imapDefaultPort);
 		} else {
-			$('#mail-imap-port').val(imapDefaultSecurePort);		
+			$('#mail-imap-port').val(imapDefaultSecurePort);
 		}
 	});
 
@@ -575,9 +575,9 @@ $(document).ready(function () {
 		var smtpDefaultSecurePort = 465;
 
 		if ($(this).val() == "none") {
-			$('#mail-smtp-port').val(smtpDefaultPort);		
+			$('#mail-smtp-port').val(smtpDefaultPort);
 		} else  {
-			$('#mail-smtp-port').val(smtpDefaultSecurePort);				
+			$('#mail-smtp-port').val(smtpDefaultSecurePort);
 		}
 	});
 

--- a/js/mail.js
+++ b/js/mail.js
@@ -23,18 +23,6 @@ var Mail = {
 	},
 	UI: {
 		initializeInterface: function () {
-			Handlebars.registerHelper("colorOfDate", function (dateInt) {
-				var lastModified = new Date(dateInt * 1000);
-				var lastModifiedTime = Math.round(lastModified.getTime() / 1000);
-
-				// date column
-				var modifiedColor = Math.round((Math.round((new Date()).getTime() / 1000) - lastModifiedTime) / 60 / 60 / 24 * 5);
-				if (modifiedColor > 200) {
-					modifiedColor = 200;
-				}
-				return 'rgb(' + modifiedColor + ',' + modifiedColor + ',' + modifiedColor + ')';
-			});
-
 			Handlebars.registerHelper("relativeModifiedDate", function (dateInt) {
 				var lastModified = new Date(dateInt * 1000);
 				var lastModifiedTime = Math.round(lastModified.getTime() / 1000);

--- a/templates/index.php
+++ b/templates/index.php
@@ -300,7 +300,7 @@
 							<option value="tls"><?php p($l->t('tls')); ?></option>
 						</select>
 				</p>
-				<p class="groupmiddle"> 
+				<p class="groupmiddle">
 					<input type="email" name="mail-imap-port" id="mail-imap-port"
 						placeholder="<?php p($l->t('IMAP Port')); ?>"
 						value="143" />

--- a/templates/index.php
+++ b/templates/index.php
@@ -66,8 +66,9 @@
 			</div>
 			<div class="date">
 					<span class="modified"
-						title="{{formatDate dateInt}}"
-						style="color:{{colorOfDate dateInt}}">{{relativeModifiedDate dateInt}}</span>
+						title="{{formatDate dateInt}}">
+						{{relativeModifiedDate dateInt}}
+					</span>
 			</div>
 			<div class="icon-delete action delete"></div>
 		</div>


### PR DESCRIPTION
It’s useful in the Files app because there files with different dates are directly among each other.

Mails however are always sorted by date so shading the date is not useful here. Removing it also fixes the visibility issues, fix #201 