### PR TITLE
Security mode fixes and improvements

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -565,10 +565,14 @@ $(document).ready(function () {
 		var imapDefaultPort = 143;
 		var imapDefaultSecurePort = 993;
 
-		if ($(this).val() === 'none') {
-			$('#mail-imap-port').val(imapDefaultPort);
-		} else {
-			$('#mail-imap-port').val(imapDefaultSecurePort);
+		switch ($(this).val()) {
+			case 'none':
+			case 'tls':
+				$('#mail-imap-port').val(imapDefaultPort);
+				break;
+			case 'ssl':
+				$('#mail-imap-port').val(imapDefaultSecurePort);
+				break;
 		}
 	});
 
@@ -576,10 +580,14 @@ $(document).ready(function () {
 		var smtpDefaultPort = 587;
 		var smtpDefaultSecurePort = 465;
 
-		if ($(this).val() === 'none') {
-			$('#mail-smtp-port').val(smtpDefaultPort);
-		} else  {
-			$('#mail-smtp-port').val(smtpDefaultSecurePort);
+		switch ($(this).val()) {
+			case 'none':
+			case 'tls':
+				$('#mail-smtp-port').val(smtpDefaultPort);
+				break;
+			case 'ssl':
+				$('#mail-smtp-port').val(smtpDefaultSecurePort);
+				break;
 		}
 	});
 

--- a/js/mail.js
+++ b/js/mail.js
@@ -573,7 +573,7 @@ $(document).ready(function () {
 	});
 
 	$(document).on('change', '#mail-smtp-sslmode', function () {
-		var smtpDefaultPort = 25;
+		var smtpDefaultPort = 587;
 		var smtpDefaultSecurePort = 465;
 
 		if ($(this).val() === 'none') {

--- a/lib/account.php
+++ b/lib/account.php
@@ -70,7 +70,7 @@ class Account {
 			$user = $this->account->getInboundUser();
 			$password = $this->account->getInboundPassword();
 			$port = $this->account->getInboundPort();
-			$ssl_mode = $this->account->getInboundSslMode();
+			$ssl_mode = $this->convertSslMode($this->account->getInboundSslMode());
 
 			$this->client = new \Horde_Imap_Client_Socket(
 				array(
@@ -193,25 +193,25 @@ class Account {
 			'password' => $this->account->getOutboundPassword(),
 			'port' => $this->account->getOutboundPort(),
 			'username' => $this->account->getOutboundUser(),
-			'secure' => $this->account->getOutboundSslMode(),
+			'secure' => $this->convertSslMode($this->account->getOutboundSslMode()),
 			'timeout' => 2
 		);
 		return new \Horde_Mail_Transport_Smtphorde($params);
 	}
-	
+
 	/**
 	 * Lists special use folders for this account.
 	 *
 	 * The special uses returned are the "best" one for each special role,
 	 * picked amongst the ones returned by the server, as well
 	 * as the one guessed by our code.
-	 * 
+	 *
 	 * @return array In the form array(<special use>=><folder id>, ...)
 	 */
 	public function getSpecialFoldersIds($base64_encode=true) {
 		$folderRoles = array('inbox', 'sent', 'drafts', 'trash', 'archive', 'junk', 'flagged', 'all');
 		$specialFoldersIds = array();
-		
+
 		foreach ($folderRoles as $role) {
 			$folders = $this->getSpecialFolder($role, true);
 			$specialFoldersIds[$role] = (count($folders) === 0) ? null : $folders[0]->getFolderId();
@@ -241,7 +241,7 @@ class Account {
 		}
 		return $sentFolders[0];
 	}
-	
+
 	/**
 	 * @param string $sourceFolderId
 	 * @param int $messageId
@@ -283,10 +283,10 @@ class Account {
 
 	/**
 	 * Get 'best' mailbox guess
-	 * 
+	 *
 	 * For now the best candidate is the one with
 	 * the most messages in it.
-	 * 
+	 *
 	 * @param array $folders
 	 * @return Mailbox
 	 */
@@ -315,9 +315,9 @@ class Account {
 	 * @param bool $guessBest If set to true, return only the folder with the most messages in it
 	 *
 	 * @return Mailbox[] if $guessBest is false, or Mailbox if $guessBest is true. Empty array() if no match.
-	 */ 
+	 */
 	protected function getSpecialFolder($role, $guessBest=true) {
-		
+
 		$specialFolders = array();
 		foreach ($this->getMailboxes() as $mailbox) {
 			if ($role === $mailbox->getSpecialRole()) {
@@ -374,8 +374,8 @@ class Account {
 	/**
 	 * Sort mailboxes
 	 *
-	 * Sort the array of mailboxes with 
-	 *  - special use folders coming first in this order: all, inbox, flagged, drafts, sent, archive, junk, trash 
+	 * Sort the array of mailboxes with
+	 *  - special use folders coming first in this order: all, inbox, flagged, drafts, sent, archive, junk, trash
 	 *  - 'normal' folders coming after that, sorted alphabetically
 	 */
 	protected function sortMailboxes() {
@@ -417,12 +417,27 @@ class Account {
 				} else {
 					return $specialRolesOrder[$roleA] - $specialRolesOrder[$roleB];
 				}
-			} 
+			}
 			// we get here if $roleA === null && $roleB === null
 			return strcasecmp($a->getDisplayName(), $b->getDisplayName());
 		});
 
 		$this->mailboxes = $mailboxes;
+	}
+
+	/**
+	 * Convert special security mode values into Horde parameters
+	 *
+	 * @param string $sslmode
+	 * @return string|bool
+	 */
+	protected function convertSslMode($sslmode) {
+		switch ($sslmode) {
+			case 'none':
+				return false;
+				break;
+		}
+		return $sslmode;
 	}
 }
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -295,9 +295,9 @@
 				<p class="groupmiddle" id="mail-imap-ssl">
 						<label for="mail-imap-sslmode"><?php p($l->t('IMAP security')); ?></label>
 						<select name="mail-imap-sslmode" id="mail-imap-sslmode" title="<?php p($l->t('IMAP security')); ?>">
-							<option value="none"><?php p($l->t('none')); ?></option>
-							<option value="ssl"><?php p($l->t('ssl')); ?></option>
-							<option value="tls"><?php p($l->t('tls')); ?></option>
+							<option value="none"><?php p($l->t('None')); ?></option>
+							<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
+							<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
 						</select>
 				</p>
 				<p class="groupmiddle">
@@ -328,9 +328,9 @@
 				<p class="groupmiddle" id="mail-smtp-ssl">
 					<label for="mail-smtp-sslmode"><?php p($l->t('SMTP security')); ?></label>
 					<select name="mail-smtp-sslmode" id="mail-smtp-sslmode" title="<?php p($l->t('SMTP security')); ?>">
-						<option value="none"><?php p($l->t('none')); ?></option>
-						<option value="ssl"><?php p($l->t('ssl')); ?></option>
-						<option value="tls"><?php p($l->t('tls')); ?></option>
+						<option value="none"><?php p($l->t('None')); ?></option>
+						<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
+						<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
 					</select>
 				</p>
 				<p class="groupmiddle">

--- a/templates/index.php
+++ b/templates/index.php
@@ -336,7 +336,7 @@
 				<p class="groupmiddle">
 					<input type="email" name="mail-smtp-port" id="mail-smtp-port"
 						placeholder="<?php p($l->t('SMTP Port')); ?>"
-						value="25" />
+						value="587" />
 					<label for="mail-smtp-port" class="infield"><?php p($l->t('SMTP Port (default 25, ssl 465)')); ?></label>
 				</p>
 				<p class="groupmiddle">


### PR DESCRIPTION
Three small changes here:

 - SMTP default port has been changed to 587, which is the SMTP submission port, and is more suitable than port 25 which is the MTA port.
 - Security mode dropdown uses nicer labels: `None`, `SSL/TLS` and `STARTTLS`, like how Mozilla Thunderbird does it.
 - I also noticed that for no security, one must pass `false` into the Horde libraries, not `none` as we are at the moment. The third commit fixes that (and implements support for adding custom security modes in the future).

Request to be merged for 0.1 @jancborchardt ?