### PR TITLE
fix Scrutinizer line break issues

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -317,8 +317,8 @@ var Mail = {
 					// Loading feedback
 					var saveToFilesBtnSelector = '.attachment-save-to-cloud';
 					if (typeof attachmentId !== "undefined") {
-						saveToFilesBtnSelector = 'li[data-attachment-id="'
-							+ attachmentId + '"] ' + saveToFilesBtnSelector;
+						saveToFilesBtnSelector = 'li[data-attachment-id="' +
+							attachmentId + '"] ' + saveToFilesBtnSelector;
 					}
 					$(saveToFilesBtnSelector)
 						.removeClass('icon-upload')
@@ -327,8 +327,9 @@ var Mail = {
 
 					$.ajax(
 						OC.generateUrl(
-							'apps/mail/accounts/{accountId}/folders/{folderId}/'
-							+ 'messages/{messageId}/attachment/{attachmentId}',
+							'apps/mail/accounts/{accountId}/' +
+								'folders/{folderId}/messages/{messageId}/' +
+								'attachment/{attachmentId}',
 							{
 								accountId: Mail.State.currentAccountId,
 								folderId: Mail.State.currentFolderId,


### PR DESCRIPTION
Fixing https://scrutinizer-ci.com/g/owncloud/mail/issues/master/files/js/mail.js?selectedAuthors%5B0%5D=hey%40jancborchardt.net&orderField=path&order=asc

Apparently the + should be last on the line, not first on the next.