### PR TITLE
Fix logging of message ID on move to trash

### DIFF
--- a/lib/account.php
+++ b/lib/account.php
@@ -295,7 +295,8 @@ class Account {
 		$result = $this->getImapConnection()->copy($hordeSourceMailBox, $hordeTrashMailBox,
 			array('create' => $createTrash, 'move' => true, 'ids' => $hordeMessageIds));
 
-		\OC::$server->getLogger()->info("Message moved to trash: {result}", array('result' => $result));
+		\OC::$server->getLogger()->info("Message moved to trash: {message} from mailbox {mailbox}",
+			array('message' => $messageId, 'mailbox' => $sourceFolderId));
 	}
 
 	/**


### PR DESCRIPTION
Array to string conversion error in log. We log message IDs in other places too, so this makes sense. I added the mailbox ID so the admin has some idea of the context.