### PR TITLE
configurable option to enable server side caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,20 @@ Go to ownCloud Mail in the browser and run this from the developer console to cl
 localStorage.clear();
 ```
 
+Configuration
+-------------
+Certain advanced or experimental features need specific enablement in config.php:
+
 ### Debug mode
-You can enable IMAP backend logging. Add this to your config.php:
+You can enable IMAP backend logging. A horde.log will appear in the same directory as your owncloud.log.
 ```php
 'app.mail.imaplog.enabled' => true
 ```
 
-A horde.log will appear in the same directory as your owncloud.log.
+### Server-side caching
+Mailbox messages and accounts can be cached on the ownCloud server to reduce mail server load:
+This requires a valid memcache to be configured
+```php
+'app.mail.server-side-cache.enabled' => true
+```
+

--- a/lib/account.php
+++ b/lib/account.php
@@ -15,6 +15,7 @@ use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Socket;
 use Horde_Imap_Client;
 use Horde_Mail_Transport_Smtphorde;
+use OCA\Mail\Cache\Cache;
 use OCA\Mail\Db\MailAccount;
 use OCP\IConfig;
 
@@ -91,6 +92,16 @@ class Account {
 			];
 			if ($this->config->getSystemValue('app.mail.imaplog.enabled', false)) {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde.log';
+			}
+			if ($this->config->getSystemValue('app.mail.server-side-cache.enabled', false)) {
+				$cacheFac = \OC::$server->getMemCacheFactory();
+				if ($cacheFac->isAvailable()) {
+					$params['cache'] = [
+						'backend' => new Cache(array(
+							'cacheob' => $cacheFac->create(md5($this->getId() . $this->getEMailAddress()))
+						))];
+				}
+
 			}
 			$this->client = new \Horde_Imap_Client_Socket($params);
 			$this->client->login();

--- a/lib/account.php
+++ b/lib/account.php
@@ -18,6 +18,7 @@ use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Cache\Cache;
 use OCA\Mail\Db\MailAccount;
 use OCP\IConfig;
+use OCP\ICacheFactory;
 
 class Account {
 
@@ -39,6 +40,9 @@ class Account {
 	/** @var IConfig */
 	private $config;
 
+	/** @var ICacheFactory */
+	private $memcacheFactory;
+
 	/**
 	 * @param MailAccount $account
 	 */
@@ -47,6 +51,7 @@ class Account {
 		$this->mailboxes = null;
 		$this->crypto = \OC::$server->getCrypto();
 		$this->config = \OC::$server->getConfig();
+		$this->memcacheFactory = \OC::$server->getMemcacheFactory();
 	}
 
 	/**
@@ -94,11 +99,11 @@ class Account {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde.log';
 			}
 			if ($this->config->getSystemValue('app.mail.server-side-cache.enabled', false)) {
-				$cacheFac = \OC::$server->getMemCacheFactory();
-				if ($cacheFac->isAvailable()) {
+				if ($this->memcacheFactory->isAvailable()) {
 					$params['cache'] = [
 						'backend' => new Cache(array(
-							'cacheob' => $cacheFac->create(md5($this->getId() . $this->getEMailAddress()))
+							'cacheob' => $this->memcacheFactory
+								->create(md5($this->getId() . $this->getEMailAddress()))
 						))];
 				}
 


### PR DESCRIPTION
This will bring back server side caching - this time configurable and using memory cache mechanisms

To enable mail caching specify this in the config.php

``` php
'app.mail.server-side-cache.enabled' => true
```

Furthermore a memory cache mechanism has to be enabled in the config - e.g. in 8.1 set  

``` php
'memcache.local' => '\OC\Memcache\APCu',
```

@jancborchardt @Gomez 
