### PR TITLE
fix layout of message list on narrower screens and mobile, do not show date for now

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -250,6 +250,7 @@
 	position: absolute;
 	right: 0;
 	top: 0;
+	max-width: 40%;
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity=50);
 	opacity: .5;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -13,5 +13,17 @@
 	width: 100%;
 }
 
+/* do not display date in message list because there is too little space */
+.date {
+	display: none;
+}
+/* more space for sender accordingly */
+.mail_message_summary_from {
+	width: 80%;
+}
+.mail_message_summary_subject {
+	width: 67%;
+}
+
 /* end of media query */
 }


### PR DESCRIPTION
The date was barely readable anyway because of overlap with the sender. So for now we don’t show it on narrow / mobile screens at all so that at least the sender is readable.

Please review @Xenopathic @zinks- @PoPoutdoor @tomneedham 