### PR TITLE
reposition message indicators, especially star, fix #570

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -408,8 +408,8 @@
 	background-size: 16px;
 	display: inline-block;
 	position: absolute;
-	top: 0;
-	left: 31px;
+	left: 25px;
+	top: 37px;
 	z-index: 10;
 }
 /* only show star on hover of row */
@@ -425,20 +425,24 @@
 .icon-reply {
 	background-image: url('../img/reply.svg');
 	position: absolute;
-	left: 9px;
+	left: 49px;
 	top: 40px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-	filter: alpha(opacity=20);
-	opacity: .2;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+	filter: alpha(opacity=50);
+	opacity: .5;
+}
+.icon-reply ~ .mail_message_summary_subject {
+	margin-left: 57px;
+	width: 65%;
 }
 
 .icon-attachment {
 	position: absolute;
-	left: 27px;
+	left: 9px;
 	top: 40px;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-	filter: alpha(opacity=20);
-	opacity: .2;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=25)";
+	filter: alpha(opacity=25);
+	opacity: .25;
 }
 
 .icon-reply,


### PR DESCRIPTION
Positioning the star left of the title instead of on the user avatar makes it clearer that it will star the message instead of the contact.

Fix https://github.com/owncloud/mail/issues/570, please review @colmoneill @Gomez @wurstchristoph @zinks- :)