### PR TITLE
Skip IMAP tests if credentials are unavailable

### DIFF
--- a/tests/imap/abstracttest.php
+++ b/tests/imap/abstracttest.php
@@ -19,13 +19,13 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase {
 
 	public static function setUpBeforeClass() {
 		if (false === \getenv('EMAIL_USER')) {
-			throw new \RuntimeException(
+			throw new \PHPUnit_Framework_SkippedTestError(
 				'Please set environment variable EMAIL_USER before running functional tests'
 			);
 		}
 
 		if (false === \getenv('EMAIL_PASSWORD')) {
-			throw new \RuntimeException(
+			throw new \PHPUnit_Framework_SkippedTestError(
 				'Please set environment variable EMAIL_PASSWORD before running functional tests'
 			);
 		}


### PR DESCRIPTION
It's annoying to see a PR marked as failed because the (encrypted) credentials sent to Travis aren't available for forks. Tests are marked as skipped instead of throwing an exception in this case. It's similar to not having the required extensions for memcache tests, as a comparison.

This PR is coming from my fork to test it.