### PR TITLE
centering the "add new email address" form

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -11,12 +11,12 @@
 
 /* SETUP */
 #mail-setup {
-	position: absolute;
 	z-index: 1001;
 	width: 250px;
-	top: 10%;
-	left: 35%;
+	top: 15%;
 	padding-bottom: 50px;
+	margin: 0 auto;
+	padding-top: 30px;
 }
 #mail-setup h2 {
 	text-align: center;
@@ -54,8 +54,11 @@
 }
 #connect-loading {
 	position: absolute;
-	top: 184px;
-	left: 43%;
+	top: 204px;
+	left: 0;
+	right: 0;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 
@@ -620,8 +623,6 @@
 .icon-trash {
 	background-image: url('../img/trash.svg');
 }
-
-
 
 /* ownCloud 7 compatibility */
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -264,9 +264,7 @@ script('mail', 'jquery-visibility');
 		<div id="mail_messages" class="icon-loading">
 		</div>
 
-		<div id="mail-message" class="icon-loading">
-		</div>
-	</div>
+
 
 	<form id="mail-setup" class="hidden" method="post">
 		<div class="hidden-visually">
@@ -282,104 +280,108 @@ script('mail', 'jquery-visibility');
 				<div class="icon-mail"></div>
 				<h2><?php p($l->t('Connect your mail account')) ?></h2>
 			</div>
-
-			<p class="grouptop">
-				<input type="text" name="mail-account-name" id="mail-account-name"
-					placeholder="<?php p($l->t('Name')); ?>"
-					value="<?php p(\OCP\User::getDisplayName(\OCP\User::getUser())); ?>"
-					autofocus />
-				<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
-			</p>
-			<p class="groupmiddle">
-				<input type="email" name="mail-address" id="mail-address"
-					placeholder="<?php p($l->t('Mail Address')); ?>"
-					value="<?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?>"
-					required />
-				<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
-			</p>
-			<p class="groupbottom">
-				<input type="password" name="mail-password" id="mail-password"
-					placeholder="<?php p($l->t('IMAP Password')); ?>" value=""
-					required />
-				<label for="mail-password" class="infield"><?php p($l->t('IMAP Password')); ?></label>
-			</p>
-
-
-			<a id="mail-setup-manual-toggle" class="icon-caret-dark"><?php p($l->t('Manual configuration')); ?></a>
-
-			<div id="mail-setup-manual" style="display:none;">
-				<p class="grouptop">
-					<input type="text" name="mail-imap-host" id="mail-imap-host"
-						placeholder="<?php p($l->t('IMAP Host')); ?>"
-						value="" />
-					<label for="mail-imap-host" class="infield"><?php p($l->t('IMAP Host')); ?></label>
-				</p>
-				<p class="groupmiddle" id="mail-imap-ssl">
-						<label for="mail-imap-sslmode"><?php p($l->t('IMAP security')); ?></label>
-						<select name="mail-imap-sslmode" id="mail-imap-sslmode" title="<?php p($l->t('IMAP security')); ?>">
-							<option value="none"><?php p($l->t('None')); ?></option>
-							<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
-							<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
-						</select>
-				</p>
-				<p class="groupmiddle">
-					<input type="number" name="mail-imap-port" id="mail-imap-port"
-						placeholder="<?php p($l->t('IMAP Port')); ?>"
-						value="143" />
-					<label for="mail-imap-port" class="infield"><?php p($l->t('IMAP Port')); ?></label>
-				</p>
-				<p class="groupmiddle">
-					<input type="text" name="mail-imap-user" id="mail-imap-user"
-						placeholder="<?php p($l->t('IMAP User')); ?>"
-						value="" />
-					<label for="mail-imap-user" class="infield"><?php p($l->t('IMAP User')); ?></label>
-				</p>
-				<p class="groupbottom">
-					<input type="password" name="mail-imap-password" id="mail-imap-password"
-						placeholder="<?php p($l->t('IMAP Password')); ?>" value=""
-						required />
-					<label for="mail-imap-password" class="infield"><?php p($l->t('IMAP Password')); ?></label>
-				</p>
-
-				<p class="grouptop">
-					<input type="text" name="mail-smtp-host" id="mail-smtp-host"
-						placeholder="<?php p($l->t('SMTP Host')); ?>"
-						value="" />
-					<label for="mail-smtp-host" class="infield"><?php p($l->t('SMTP Host')); ?></label>
-				</p>
-				<p class="groupmiddle" id="mail-smtp-ssl">
-					<label for="mail-smtp-sslmode"><?php p($l->t('SMTP security')); ?></label>
-					<select name="mail-smtp-sslmode" id="mail-smtp-sslmode" title="<?php p($l->t('SMTP security')); ?>">
-						<option value="none"><?php p($l->t('None')); ?></option>
-						<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
-						<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
-					</select>
-				</p>
-				<p class="groupmiddle">
-					<input type="number" name="mail-smtp-port" id="mail-smtp-port"
-						placeholder="<?php p($l->t('SMTP Port')); ?>"
-						value="587" />
-					<label for="mail-smtp-port" class="infield"><?php p($l->t('SMTP Port (default 25, ssl 465)')); ?></label>
-				</p>
-				<p class="groupmiddle">
-					<input type="text" name="mail-smtp-user" id="mail-smtp-user"
-						placeholder="<?php p($l->t('SMTP User')); ?>"
-						value="" />
-					<label for="mail-smtp-user" class="infield"><?php p($l->t('SMTP User')); ?></label>
-				</p>
-				<p class="groupbottom">
-					<input type="password" name="mail-smtp-password" id="mail-smtp-password"
-						placeholder="<?php p($l->t('SMTP Password')); ?>" value=""
-						required />
-					<label for="mail-smtp-password" class="infield"><?php p($l->t('SMTP Password')); ?></label>
-				</p>
-			</div>
+					<p class="grouptop">
+						<input type="text" name="mail-account-name" id="mail-account-name"
+							placeholder="<?php p($l->t('Name')); ?>"
+							value="<?php p(\OCP\User::getDisplayName(\OCP\User::getUser())); ?>"
+							autofocus />
+						<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
+					</p>
+					<p class="groupmiddle">
+						<input type="email" name="mail-address" id="mail-address"
+							placeholder="<?php p($l->t('Mail Address')); ?>"
+							value="<?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?>"
+							required />
+						<label for="mail-address" class="infield"><?php p($l->t('Mail Address')); ?></label>
+					</p>
+					<p class="groupbottom">
+						<input type="password" name="mail-password" id="mail-password"
+							placeholder="<?php p($l->t('IMAP Password')); ?>" value=""
+							required />
+						<label for="mail-password" class="infield"><?php p($l->t('IMAP Password')); ?></label>
+					</p>
 
 
-			<img id="connect-loading" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" style="display:none;" />
-			<input type="submit" id="auto_detect_account" class="connect primary" value="<?php p($l->t('Connect')); ?>"/>
-		</fieldset>
-	</form>
+					<a id="mail-setup-manual-toggle" class="icon-caret-dark"><?php p($l->t('Manual configuration')); ?></a>
 
+					<div id="mail-setup-manual" style="display:none;">
+						<p class="grouptop">
+							<input type="text" name="mail-imap-host" id="mail-imap-host"
+								placeholder="<?php p($l->t('IMAP Host')); ?>"
+								value="" />
+							<label for="mail-imap-host" class="infield"><?php p($l->t('IMAP Host')); ?></label>
+						</p>
+						<p class="groupmiddle" id="mail-imap-ssl">
+								<label for="mail-imap-sslmode"><?php p($l->t('IMAP security')); ?></label>
+								<select name="mail-imap-sslmode" id="mail-imap-sslmode" title="<?php p($l->t('IMAP security')); ?>">
+									<option value="none"><?php p($l->t('None')); ?></option>
+									<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
+									<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
+								</select>
+						</p>
+						<p class="groupmiddle">
+							<input type="number" name="mail-imap-port" id="mail-imap-port"
+								placeholder="<?php p($l->t('IMAP Port')); ?>"
+								value="143" />
+							<label for="mail-imap-port" class="infield"><?php p($l->t('IMAP Port')); ?></label>
+						</p>
+						<p class="groupmiddle">
+							<input type="text" name="mail-imap-user" id="mail-imap-user"
+								placeholder="<?php p($l->t('IMAP User')); ?>"
+								value="" />
+							<label for="mail-imap-user" class="infield"><?php p($l->t('IMAP User')); ?></label>
+						</p>
+						<p class="groupbottom">
+							<input type="password" name="mail-imap-password" id="mail-imap-password"
+								placeholder="<?php p($l->t('IMAP Password')); ?>" value=""
+								required />
+							<label for="mail-imap-password" class="infield"><?php p($l->t('IMAP Password')); ?></label>
+						</p>
+
+						<p class="grouptop">
+							<input type="text" name="mail-smtp-host" id="mail-smtp-host"
+								placeholder="<?php p($l->t('SMTP Host')); ?>"
+								value="" />
+							<label for="mail-smtp-host" class="infield"><?php p($l->t('SMTP Host')); ?></label>
+						</p>
+						<p class="groupmiddle" id="mail-smtp-ssl">
+							<label for="mail-smtp-sslmode"><?php p($l->t('SMTP security')); ?></label>
+							<select name="mail-smtp-sslmode" id="mail-smtp-sslmode" title="<?php p($l->t('SMTP security')); ?>">
+								<option value="none"><?php p($l->t('None')); ?></option>
+								<option value="ssl"><?php p($l->t('SSL/TLS')); ?></option>
+								<option value="tls"><?php p($l->t('STARTTLS')); ?></option>
+							</select>
+						</p>
+						<p class="groupmiddle">
+							<input type="number" name="mail-smtp-port" id="mail-smtp-port"
+								placeholder="<?php p($l->t('SMTP Port')); ?>"
+								value="587" />
+							<label for="mail-smtp-port" class="infield"><?php p($l->t('SMTP Port (default 25, ssl 465)')); ?></label>
+						</p>
+						<p class="groupmiddle">
+							<input type="text" name="mail-smtp-user" id="mail-smtp-user"
+								placeholder="<?php p($l->t('SMTP User')); ?>"
+								value="" />
+							<label for="mail-smtp-user" class="infield"><?php p($l->t('SMTP User')); ?></label>
+						</p>
+						<p class="groupbottom">
+							<input type="password" name="mail-smtp-password" id="mail-smtp-password"
+								placeholder="<?php p($l->t('SMTP Password')); ?>" value=""
+								required />
+							<label for="mail-smtp-password" class="infield"><?php p($l->t('SMTP Password')); ?></label>
+						</p>
+					</div>
+
+
+					<img id="connect-loading" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" style="display:none;" />
+					<input type="submit" id="auto_detect_account" class="connect primary" value="<?php p($l->t('Connect')); ?>"/>
+				</fieldset>
+			</form>
+
+
+
+		<div id="mail-message" class="icon-loading">
+		</div>
+	</div>
 
 </div>


### PR DESCRIPTION
Tiny tiny change, as pointed out in #567; centring the new email form to the middle of the viewport.

Given the 'absolute positioning' nature of this app, I'm centring to the middle of the browser, not the middle of the left pannel. The difference being that on first launch of the Mail app in oC, you get this form prompt with no left menu, as the screenshot in #567 shows.