### PR TITLE
fix account form being autofilled with username and password in Chrome & Safari

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -267,6 +267,14 @@ script('mail', 'jquery-visibility');
 	</div>
 
 	<form id="mail-setup" class="hidden" method="post">
+		<div class="hidden-visually">
+			<!-- Hack for Safari and Chromium/Chrome which ignore autocomplete="off" -->
+			<input type="text" id="fake_user" name="fake_user"
+				autocomplete="off" tabindex="-1">
+			<input type="password" id="fake_password" name="fake_password"
+				autocomplete="off" tabindex="-1">
+		</div>
+
 		<fieldset>
 			<div id="emptycontent">
 				<div class="icon-mail"></div>


### PR DESCRIPTION
fix #566 

Please review @colmoneill @blizzz @Xenopathic @wurstchristoph @irgendwie 

@blizzz thank you for the code! :) As you see you can improve yours by using the standard `.hidden-visually` class from core, as well as adding `tabindex="-1"` so it doesn’t interfere with keyboard navigation.