### PR TITLE
Revert "getStatus()->utf8/utf7imap does not always return with INBOX pre...

### DIFF
--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -160,13 +160,7 @@ class Mailbox {
 	}
 
 	public function getFolderId() {
-		$folderId = $this->mailBox->utf8;
-
-		if (strlen($folderId) > 6 && strpos($folderId, 'INBOX' . $this->delimiter) === 0) {
-			return substr($folderId, 6);
-		}
-
-		return $folderId;
+		return $this->mailBox->utf8;
 	}
 
 	/**


### PR DESCRIPTION
...fix, let's clean it up for good"

This reverts commit ba2ef7c050213672d0eec502bbab0800af115f11.

Fixes #626, #617 

Confirmed working by me, @sndrsk and @clementhk 

@clementhk You introduced this change in the first place a few days ago, what was the original intent?