### PR TITLE
on failed connection activate send/reply button again

### DIFF
--- a/js/send-mail.js
+++ b/js/send-mail.js
@@ -108,6 +108,7 @@ $(function () {
 			complete:function () {
 				replyMessageBody.removeClass('icon-loading');
 				replyMessageBody.prop('disabled', false);
+				replyMessageSend.prop('disabled', false);
 				replyMessageSend.val(t('mail', 'Reply'));
 				$('.reply-message-fields #to').prop('disabled', false);
 				$('.reply-message-fields #cc').prop('disabled', false);

--- a/js/views/sendmail.js
+++ b/js/views/sendmail.js
@@ -155,19 +155,21 @@ views.SendMail = Backbone.View.extend({
 				}
 			},
 			error: function (jqXHR) {
+				newMessageSend.prop('disabled', false);
 				OC.Notification.showTemporary(jqXHR.responseJSON.message);
 			},
 			complete: function() {
 				// remove loading feedback
 				newMessageBody.removeClass('icon-loading');
 				$('.mail_account').prop('disabled', false);
-				$('#to').prop('disabled', false);
-				$('#cc').prop('disabled', false);
-				$('#bcc').prop('disabled', false);
-				$('#subject').prop('disabled', false);
+				to.prop('disabled', false);
+				cc.prop('disabled', false);
+				bcc.prop('disabled', false);
+				subject.prop('disabled', false);
 				$('.new-message-attachments-action').css('display', 'inline-block');
 				$('#mail_new_attachment').prop('disabled', false);
 				newMessageBody.prop('disabled', false);
+				newMessageSend.prop('disabled', false);
 				newMessageSend.val(t('mail', 'Send'));
 			}
 		});


### PR DESCRIPTION
fix #606. The notification vanishing when in the background is a core issue, see https://github.com/owncloud/core/issues/16121

Please review @DeepDiver1975 @wurstchristoph @Xenopathic @irgendwie 

To test:
1. Load mail app
2. Compose reply or new message
3. Deactivate your wifi
4. Press »send« or »reply«
5. See the error and see the buttons being active again
