### PR TITLE
Fixed the way the Flagged mailbox gets its display name

### DIFF
--- a/lib/account.php
+++ b/lib/account.php
@@ -449,7 +449,7 @@ class Account {
 			// TRANSLATORS: translated mail box name
 			'all'     => $l->t('All'),
 			// TRANSLATORS: translated mail box name
-			'flagged' => $l->t('Starred'),
+			'flagged' => $l->t('Favorites'),
 		];
 		$mailboxes = $this->getMailboxes();
 		$specialIds = $this->getSpecialFoldersIds(false);

--- a/lib/searchmailbox.php
+++ b/lib/searchmailbox.php
@@ -11,6 +11,7 @@ namespace OCA\Mail;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
+use Horde_Imap_Client;
 
 class SearchMailbox extends Mailbox {
 
@@ -21,8 +22,8 @@ class SearchMailbox extends Mailbox {
 	 * @param string $delimiter
 	 */
 	function __construct($conn, $mailBox, $attributes, $delimiter = '/') {
+                $attributes[] = Horde_Imap_Client::SPECIALUSE_FLAGGED;
 		parent::__construct($conn, $mailBox, $attributes, $delimiter);
-		parent::setDisplayName('Favorites');
 	}
 
 	public function getMessages($from = 0, $count = 2, $filter = '') {
@@ -35,10 +36,6 @@ class SearchMailbox extends Mailbox {
 		return parent::getMessages($from, $count, $query);
 	}
 
-	public function setDisplayName($displayName) {
-
-	}
-
 	public function getFolderId() {
 		return parent::getFolderId() . '/FLAGGED';
 	}
@@ -47,11 +44,7 @@ class SearchMailbox extends Mailbox {
 		return null;
 	}
 
-	public function getSpecialRole() {
-		return 'flagged';
-	}
-
-	public function getStatus($flags = \Horde_Imap_Client::STATUS_ALL) {
+	public function getStatus() {
 		$status = parent::getStatus();
 		$status['unseen'] = 0;
 


### PR DESCRIPTION
Fixes #690 , replaces #692 
The only issue I can see here if if the parent mailbox already has a special use IMAP attribute set, then would end up with two.