### PR TITLE
Make redirect in Firefox work again and harden CSP policy

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -166,16 +166,20 @@ class MessagesController extends Controller {
 			$m = $mailBox->getMessage($messageId, true);
 			$html = $m->getHtmlBody();
 
-			// Harden the default security policy
-			$policy = new ContentSecurityPolicy();
-			$policy->allowEvalScript(false);
-			$policy->disallowScriptDomain('\'self\'');
-			$policy->disallowConnectDomain('\'self\'');
-			$policy->disallowFontDomain('\'self\'');
-			$policy->disallowMediaDomain('\'self\'');
-
 			$htmlResponse = new HtmlResponse($html);
-			$htmlResponse->setContentSecurityPolicy($policy);
+
+			// Harden the default security policy
+			// FIXME: Remove once ownCloud 8.1 is a requirement for the mail app
+			if(class_exists('\OCP\AppFramework\Http\ContentSecurityPolicy')) {
+				$policy = new ContentSecurityPolicy();
+				$policy->allowEvalScript(false);
+				$policy->disallowScriptDomain('\'self\'');
+				$policy->disallowConnectDomain('\'self\'');
+				$policy->disallowFontDomain('\'self\'');
+				$policy->disallowMediaDomain('\'self\'');
+				$htmlResponse->setContentSecurityPolicy($policy);
+			}
+
 			return $htmlResponse;
 		} catch(\Exception $ex) {
 			return new TemplateResponse($this->appName, 'error', ['message' => $ex->getMessage()], 'none');

--- a/templates/index.php
+++ b/templates/index.php
@@ -98,7 +98,7 @@ script('mail', 'jquery-visibility');
 		<div id="mail-content">
 			{{#if hasHtmlBody}}
 			<div class="icon-loading">
-				<iframe src="{{htmlBodyUrl}}" sandbox="allow-popups allow-same-origin" seamless>
+				<iframe src="{{htmlBodyUrl}}" seamless>
 				</iframe>
 			</div>
 			{{else}}


### PR DESCRIPTION
This makes the redirect in Firefox work again by using CSP instead of a sandboxed iframe. Unit tests are coming later because the message controller has some hard-coded references to other classes with side-effect such as `\OCA\Mail\Account`. Trying to come up with a fix for that as well in another PR.

Requires https://github.com/owncloud/core/pull/16463 for optimal security. Should work without though.

Fixes https://github.com/owncloud/mail/issues/206

cc @DeepDiver1975 @jancborchardt 