### PR TITLE
Fix SearchMailbox::getStatus()

### DIFF
--- a/lib/searchmailbox.php
+++ b/lib/searchmailbox.php
@@ -44,8 +44,8 @@ class SearchMailbox extends Mailbox {
 		return null;
 	}
 
-	public function getStatus() {
-		$status = parent::getStatus();
+	public function getStatus($flags = \Horde_Imap_Client::STATUS_ALL) {
+		$status = parent::getStatus($flags);
 		$status['unseen'] = 0;
 
 		return $status;


### PR DESCRIPTION
Amended previous changes I made to SearchMailbox::getStatus() that fixed a scrutinizer issue the wrong way

ref https://github.com/owncloud/mail/pull/694#issuecomment-104562731

@jancborchardt @DeepDiver1975 check it out