### PR TITLE
show ellipsis on long mail addresses

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -153,11 +153,12 @@
 	position: absolute;
 }
 
-.mail_account_email {
+.mail-account-email {
 	opacity: .5;
 	padding: 20px 0 10px 12px;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -37,7 +37,7 @@ script('mail', 'jquery-visibility');
 	</li>
 </script>
 <script id="mail-account-template" type="text/x-handlebars-template">
-	<h2 class="mail_account_email">{{email}}</h2>
+	<h2 class="mail-account-email" title="{{email}}">{{email}}</h2>
 	<ul id="mail_folders" class="mail_folders with-icon" data-account_id="{{id}}">
 	</ul>
 </script>


### PR DESCRIPTION
fixes #726 

Now it looks like this:
![](https://cloud.githubusercontent.com/assets/1374172/7809373/e9c0039c-0399-11e5-8481-4c71f7b7d758.png)

@jancborchardt is there a way to show the full text when hovering?
