### PR TITLE
Unified Inbox

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -47,7 +47,8 @@ class Application extends App {
 		$container->registerService('AccountService', function($c) {
 			/** @var IAppContainer $c */
 			return new AccountService(
-				$c->query('MailAccountMapper')
+				$c->query('MailAccountMapper'),
+				$c->getServer()->getL10N('mail')
 			);
 		});
 

--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -16,6 +16,7 @@ use OCA\Mail\Controller\FoldersController;
 use OCA\Mail\Controller\MessagesController;
 use OCA\Mail\Controller\ProxyController;
 use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AutoConfig;
 use OCA\Mail\Service\ContactsIntegration;
 use OCA\Mail\Service\Logger;
@@ -43,12 +44,19 @@ class Application extends App {
 			);
 		});
 
+		$container->registerService('AccountService', function($c) {
+			/** @var IAppContainer $c */
+			return new AccountService(
+				$c->query('MailAccountMapper')
+			);
+		});
+
 		$container->registerService('AccountsController', function($c) {
 			/** @var IAppContainer $c */
 			return new AccountsController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('MailAccountMapper'),
+				$c->query('AccountService'),
 				$c->query('UserId'),
 				$c->getServer()->getUserFolder(),
 				$c->query('ContactsIntegration'),
@@ -64,7 +72,7 @@ class Application extends App {
 			return new FoldersController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('MailAccountMapper'),
+				$c->query('AccountService'),
 				$c->query('UserId')
 			);
 		});
@@ -74,7 +82,7 @@ class Application extends App {
 			return new MessagesController(
 				$c->query('AppName'),
 				$c->query('Request'),
-				$c->query('MailAccountMapper'),
+				$c->query('AccountService'),
 				$c->query('UserId'),
 				$c->getServer()->getUserFolder(),
 				$c->query('ContactsIntegration'),

--- a/css/mail.css
+++ b/css/mail.css
@@ -177,11 +177,9 @@
 
 .mail-message-account-color {
 	position: absolute;
-	width: 3px;
+	width: 5px;
 	height: 69px;
 	z-index: 1;
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-	opacity: .5;
 }
 
 

--- a/css/mail.css
+++ b/css/mail.css
@@ -157,11 +157,31 @@
 }
 
 .mail-account-email {
+	display: inline-block;
 	opacity: .5;
-	padding: 20px 0 10px 12px;
+	padding: 20px 0 10px 25px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.mail-account-color {
+	display: inline-block;
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	position: relative;
+	left: 15px;
+	top: -12px;
+}
+
+.mail-message-account-color {
+	position: absolute;
+	width: 3px;
+	height: 69px;
+	z-index: 1;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+	opacity: .5;
 }
 
 

--- a/js/mail.js
+++ b/js/mail.js
@@ -434,9 +434,12 @@ var Mail = {
 		var composerVisible = false;
 
 		this.renderSettings = function() {
+			var accounts = _.filter(Mail.State.accounts, function(item) {
+				return item.accountId !== -1;
+			});
 			var source   = $("#mail-settings-template").html();
 			var template = Handlebars.compile(source);
-			var html = template(Mail.State.accounts);
+			var html = template(accounts);
 			$('#app-settings-content').html(html);
 		};
 

--- a/js/mail.js
+++ b/js/mail.js
@@ -725,11 +725,12 @@ var Mail = {
 								Mail.UI.addMessages(jsondata);
 
 								// Fetch first 10 messages in background
-								_.each(jsondata.slice(0, 10), function(message) {
+								var first10 = Mail.State.messageView.collection.first(10);
+								_.each(first10, function (message) {
 									Mail.BackGround.messageFetcher.push(message.id);
 								});
 
-								var messageId = jsondata[0].id;
+								var messageId = Mail.State.messageView.collection.first().get('id');
 								Mail.UI.loadMessage(messageId);
 								// Show 'Load More' button if there are
 								// more messages than the pagination limit

--- a/js/mail.js
+++ b/js/mail.js
@@ -1,4 +1,4 @@
-/* global Handlebars, Marionette, Notification, relative_modified_date, formatDate, humanFileSize, views, OC, _ */
+/* global Handlebars, Marionette, Notification, relative_modified_date, formatDate, humanFileSize, views, OC, _, md5 */
 
 if (_.isUndefined(OC.Notification.showTemporary)) {
 
@@ -123,7 +123,7 @@ var Mail = {
 			var storage = $.localStorage;
 			_.each(storage.get('messages'), function(account, accountId) {
 				var isActive = _.any(activeAccounts, function(a) {
-					return a === parseInt(accountId);
+					return a === parseInt(accountId, 10);
 				});
 				if (!isActive) {
 					// Account does not exist anymore -> remove it
@@ -482,8 +482,15 @@ var Mail = {
 				return humanFileSize(size);
 			});
 
-			Handlebars.registerHelper("printAddressList", function(addressList) {
-				var currentAddress = _.find(Mail.State.accounts, function(item) {
+			Handlebars.registerHelper('accountColor', function (account) {
+				var hash = md5(account),
+					maxRange = parseInt('ffffffffffffffffffffffffffffffff', 16),
+					hue = parseInt(hash, 16) / maxRange * 256;
+				return new Handlebars.SafeString('hsl(' + hue + ', 90%, 65%)');
+			});
+
+			Handlebars.registerHelper("printAddressList", function (addressList) {
+				var currentAddress = _.find(Mail.State.accounts, function (item) {
 					return item.accountId === Mail.State.currentAccountId;
 				});
 

--- a/js/views/sendmail.js
+++ b/js/views/sendmail.js
@@ -34,7 +34,11 @@ views.SendMail = Backbone.View.extend({
 
 	initialize: function(options) {
 		this.attachments = new models.Attachments();
-		this.aliases = options.aliases;
+
+		this.aliases = _.filter(options.aliases, function(item) {
+			return item.accountId !== -1;
+		});
+
 		if (options.data) {
 			this.data = options.data;
 			this.draftUID = options.data.id;

--- a/lib/account.php
+++ b/lib/account.php
@@ -17,11 +17,13 @@ use Horde_Imap_Client;
 use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Cache\Cache;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\IAccount;
+use OCA\Mail\Service\IMailBox;
 use OCP\IConfig;
 use OCP\ICacheFactory;
 use OCP\Security\ICrypto;
 
-class Account {
+class Account implements IAccount {
 
 	/**
 	 * @var MailAccount
@@ -296,6 +298,15 @@ class Account {
 		return $draftsFolder[0];
 	}
 
+
+	/**
+	 * @return IMailBox
+	 */
+	public function getInbox() {
+		$folders =  $this->getSpecialFolder('inbox', false);
+		return count($folders) > 0 ? $folders[0] : null;
+	}
+
 	/**
 	 * Get the "sent mail" mailbox
 	 *
@@ -523,15 +534,15 @@ class Account {
 	/**
 	 * Convert special security mode values into Horde parameters
 	 *
-	 * @param string $sslmode
+	 * @param string $sslMode
 	 * @return false|string
 	 */
-	protected function convertSslMode($sslmode) {
-		switch ($sslmode) {
+	protected function convertSslMode($sslMode) {
+		switch ($sslMode) {
 			case 'none':
 				return false;
 		}
-		return $sslmode;
+		return $sslMode;
 	}
 
 	/**
@@ -596,6 +607,20 @@ class Account {
 			$this->client = null;
 		}
 		$this->getImapConnection();
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getConfiguration() {
+		return $this->account->toJson();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEmail() {
+		return $this->account->getEmail();
 	}
 }
 

--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -245,8 +245,13 @@ class AccountsController extends Controller {
 		$bcc = $this->params('bcc');
 		$draftUID = $this->params('draftUID');
 
-		$dbAccount = $this->accountService->find($this->currentUserId, $accountId);
-		$account = new Account($dbAccount);
+		$account = $this->accountService->find($this->currentUserId, $accountId);
+		if (!$account instanceof Account) {
+			return new JSONResponse(
+				array('message' => 'Invalid account'),
+				Http::STATUS_BAD_REQUEST
+			);
+		}
 
 		// get sender data
 		$headers = [];
@@ -366,8 +371,13 @@ class AccountsController extends Controller {
 			$this->logger->info("Updating draft <$uid> in account <$accountId>");
 		}
 
-		$dbAccount = $this->accountService->find($this->currentUserId, $accountId);
-		$account = new Account($dbAccount);
+		$account = $this->accountService->find($this->currentUserId, $accountId);
+		if (!$account instanceof Account) {
+			return new JSONResponse(
+				array('message' => 'Invalid account'),
+				Http::STATUS_BAD_REQUEST
+			);
+		}
 
 		// get sender data
 		$headers = [];

--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -29,6 +29,7 @@ use Horde_Mime_Part;
 use Horde_Mail_Rfc822_Address;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AutoConfig;
 use OCA\Mail\Service\ContactsIntegration;
 use OCP\AppFramework\Controller;
@@ -42,10 +43,9 @@ use OCP\ILogger;
 use OCP\Security\ICrypto;
 
 class AccountsController extends Controller {
-	/**
-	 * @var \OCA\Mail\Db\MailAccountMapper
-	 */
-	private $mapper;
+
+	/** @var AccountService */
+	private $accountService;
 
 	/**
 	 * @var string
@@ -94,7 +94,7 @@ class AccountsController extends Controller {
 	 */
 	public function __construct($appName,
 		$request,
-		$mailAccountMapper,
+		$accountService,
 		$currentUserId,
 		$userFolder,
 		$contactsIntegration,
@@ -104,7 +104,7 @@ class AccountsController extends Controller {
 		ICrypto $crypto
 	) {
 		parent::__construct($appName, $request);
-		$this->mapper = $mailAccountMapper;
+		$this->accountService = $accountService;
 		$this->currentUserId = $currentUserId;
 		$this->userFolder = $userFolder;
 		$this->contactsIntegration = $contactsIntegration;
@@ -119,11 +119,11 @@ class AccountsController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function index() {
-		$mailAccounts = $this->mapper->findByUserId($this->currentUserId);
+		$mailAccounts = $this->accountService->findByUserId($this->currentUserId);
 
 		$json = [];
 		foreach ($mailAccounts as $mailAccount) {
-			$json[] = $mailAccount->toJson();
+			$json[] = $mailAccount->getConfiguration();
 		}
 
 		return new JSONResponse($json);
@@ -137,9 +137,9 @@ class AccountsController extends Controller {
 	 */
 	public function show($accountId) {
 		try {
-			$account = $this->mapper->find($this->currentUserId, $accountId);
+			$account = $this->accountService->find($this->currentUserId, $accountId);
 
-			return new JSONResponse($account->toJson());
+			return new JSONResponse($account->getConfiguration());
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], 404);
 		}
@@ -162,8 +162,7 @@ class AccountsController extends Controller {
 	 */
 	public function destroy($accountId) {
 		try {
-			$mailAccount = $this->mapper->find($this->currentUserId, $accountId);
-			$this->mapper->delete($mailAccount);
+			$this->accountService->delete($this->currentUserId, $accountId);
 
 			return new JSONResponse();
 		} catch (DoesNotExistException $e) {
@@ -212,7 +211,7 @@ class AccountsController extends Controller {
 			}
 
 			if ($newAccount) {
-				$this->mapper->save($newAccount);
+				$this->accountService->save($newAccount);
 				$this->logger->debug("account created " . $newAccount->getId());
 				return new JSONResponse(
 					['data' => ['id' => $newAccount->getId()]],
@@ -246,7 +245,7 @@ class AccountsController extends Controller {
 		$bcc = $this->params('bcc');
 		$draftUID = $this->params('draftUID');
 
-		$dbAccount = $this->mapper->find($this->currentUserId, $accountId);
+		$dbAccount = $this->accountService->find($this->currentUserId, $accountId);
 		$account = new Account($dbAccount);
 
 		// get sender data
@@ -367,7 +366,7 @@ class AccountsController extends Controller {
 			$this->logger->info("Updating draft <$uid> in account <$accountId>");
 		}
 
-		$dbAccount = $this->mapper->find($this->currentUserId, $accountId);
+		$dbAccount = $this->accountService->find($this->currentUserId, $accountId);
 		$account = new Account($dbAccount);
 
 		// get sender data

--- a/lib/controller/folderscontroller.php
+++ b/lib/controller/folderscontroller.php
@@ -23,6 +23,7 @@
 namespace OCA\Mail\Controller;
 
 use OCA\Mail\Account;
+use OCA\Mail\Service\AccountService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\JSONResponse;
@@ -30,10 +31,8 @@ use OCP\AppFramework\Http;
 
 class FoldersController extends Controller {
 
-	/**
-	 * @var \OCA\Mail\Db\MailAccountMapper
-	 */
-	private $mapper;
+	/** @var AccountService */
+	private $accountService;
 
 	/**
 	 * @var string
@@ -46,9 +45,9 @@ class FoldersController extends Controller {
 	 * @param $mailAccountMapper
 	 * @param $currentUserId
 	 */
-	public function __construct($appName, $request, $mailAccountMapper, $currentUserId){
+	public function __construct($appName, $request, $accountService, $currentUserId){
 		parent::__construct($appName, $request);
-		$this->mapper = $mailAccountMapper;
+		$this->accountService = $accountService;
 		$this->currentUserId = $currentUserId;
 	}
 
@@ -58,8 +57,7 @@ class FoldersController extends Controller {
 	 */
 	public function index() {
 		$account = $this->getAccount();
-		$m = new Account($account);
-		$json = $m->getListArray();
+		$json = $account->getListArray();
 
 		$folders = array_filter($json['folders'], function($folder){
 			return is_null($folder['parent']);
@@ -168,8 +166,7 @@ class FoldersController extends Controller {
 				$query[$folderId] = $folder;
 			}
 			$account = $this->getAccount();
-			$m = new Account($account);
-			$mailBoxes = $m->getChangedMailboxes($query);
+			$mailBoxes = $account->getChangedMailboxes($query);
 
 			return new JSONResponse($mailBoxes);
 		} catch (\Horde_Imap_Client_Exception $e) {
@@ -184,9 +181,8 @@ class FoldersController extends Controller {
 	/**
 	 * TODO: private functions below have to be removed from controller -> imap service to be build
 	 */
-	private function getAccount()
-	{
+	private function getAccount() {
 		$accountId = $this->params('accountId');
-		return $this->mapper->find($this->currentUserId, $accountId);
+		return $this->accountService->find($this->currentUserId, $accountId);
 	}
 }

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -160,7 +160,7 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @return JSONResponse
 	 */
 	public function getHtmlBody($messageId) {
@@ -194,7 +194,7 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @param string $attachmentId
 	 * @return AttachmentDownloadResponse
 	 */
@@ -213,7 +213,7 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @param string $attachmentId
 	 * @param string $targetPath
 	 * @return JSONResponse
@@ -252,7 +252,7 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @param boolean $starred
 	 * @return JSONResponse
 	 */
@@ -267,13 +267,13 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $id
+	 * @param string $messageId
 	 * @return JSONResponse
 	 */
-	public function destroy($id) {
+	public function destroy($messageId) {
 		try {
 			$account = $this->getAccount();
-			$account->deleteMessage(base64_decode($this->params('folderId')), $id);
+			$account->deleteMessage(base64_decode($this->params('folderId')), $messageId);
 			return new JSONResponse();
 
 		} catch (DoesNotExistException $e) {
@@ -299,16 +299,16 @@ class MessagesController extends Controller {
 	}
 
 	/**
-	 * @param integer $id
+	 * @param string $messageId
 	 * @param $accountId
 	 * @param $folderId
 	 * @return callable
 	 */
-	private function enrichDownloadUrl($accountId, $folderId, $id, $attachment) {
+	private function enrichDownloadUrl($accountId, $folderId, $messageId, $attachment) {
 		$downloadUrl = \OCP\Util::linkToRoute('mail.messages.downloadAttachment', [
 			'accountId' => $accountId,
 			'folderId' => $folderId,
-			'messageId' => $id,
+			'messageId' => $messageId,
 			'attachmentId' => $attachment['id'],
 		]);
 		$downloadUrl = \OC::$server->getURLGenerator()->getAbsoluteURL($downloadUrl);
@@ -320,14 +320,14 @@ class MessagesController extends Controller {
 	/**
 	 * @param string $accountId
 	 * @param string $folderId
-	 * @param string $id
+	 * @param string $messageId
 	 * @return string
 	 */
-	private function buildHtmlBodyUrl($accountId, $folderId, $id) {
+	private function buildHtmlBodyUrl($accountId, $folderId, $messageId) {
 		$htmlBodyUrl = \OC::$server->getURLGenerator()->linkToRoute('mail.messages.getHtmlBody', [
 			'accountId' => $accountId,
 			'folderId' => $folderId,
-			'messageId' => $id,
+			'messageId' => $messageId,
 			'requesttoken' => \OCP\Util::callRegister(),
 		]);
 		return \OC::$server->getURLGenerator()->getAbsoluteURL($htmlBodyUrl);

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -267,13 +267,13 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param string $messageId
+	 * @param string $id
 	 * @return JSONResponse
 	 */
-	public function destroy($messageId) {
+	public function destroy($id) {
 		try {
 			$account = $this->getAccount();
-			$account->deleteMessage(base64_decode($this->params('folderId')), $messageId);
+			$account->deleteMessage(base64_decode($this->params('folderId')), $id);
 			return new JSONResponse();
 
 		} catch (DoesNotExistException $e) {

--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -13,8 +13,9 @@ use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
+use OCA\Mail\Service\IMailBox;
 
-class Mailbox {
+class Mailbox implements IMailBox {
 
 	/**
 	 * @var Horde_Imap_Client_Socket
@@ -405,4 +406,5 @@ class Mailbox {
 	public function getHordeMailBox() {
 		return $this->mailBox;
 	}
+
 }

--- a/lib/message.php
+++ b/lib/message.php
@@ -35,6 +35,9 @@ class Message {
 	 */
 	private $attachmentsToIgnore = ['signature.asc', 'smime.p7s'];
 
+	/** @var string */
+	private $uid;
+
 	/**
 	 * @param \Horde_Imap_Client_Socket|null $conn
 	 * @param \Horde_Imap_Client_Mailbox $mailBox
@@ -89,7 +92,18 @@ class Message {
 	 * @return int
 	 */
 	public function getUid() {
+		if (!is_null($this->uid)) {
+			return $this->uid;
+		}
 		return $this->fetch->getUid();
+	}
+
+	public function setUid($uid) {
+		$this->uid = $uid;
+		$this->attachments = array_map(function($attachment) use ($uid) {
+			$attachment['messageId'] = $uid;
+			return $attachment;
+		}, $this->attachments);
 	}
 
 	/**

--- a/lib/service/accountservice.php
+++ b/lib/service/accountservice.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+
+class AccountService {
+
+	/**
+	 * @var \OCA\Mail\Db\MailAccountMapper
+	 */
+	private $mapper;
+
+	/**
+	 * @param MailAccountMapper $mapper
+	 */
+	public function __construct($mapper) {
+		$this->mapper = $mapper;
+	}
+
+	/**
+	 * @param string $currentUserId
+	 * @return IAccount[]
+	 */
+	public function findByUserId($currentUserId) {
+		$accounts = $this->mapper->findByUserId($currentUserId);
+		$accounts = array_map(function($a) {
+			return new Account($a);
+		}, $accounts);
+		if (count($accounts) > 1) {
+			$unifiedAccount = $this->buildUnifiedAccount($currentUserId);
+			$accounts = array_merge([$unifiedAccount], $accounts);
+		}
+
+		return $accounts;
+	}
+
+	/**
+	 * @param $currentUserId
+	 * @param $accountId
+	 * @return IAccount
+	 */
+	public function find($currentUserId, $accountId) {
+		if ((int)$accountId === UnifiedAccount::ID) {
+			return $this->buildUnifiedAccount($currentUserId);
+		}
+		return new Account($this->mapper->find($currentUserId, $accountId));
+	}
+
+	/**
+	 * @param int $accountId
+	 */
+	public function delete($currentUserId, $accountId) {
+		if ((int)$accountId === UnifiedAccount::ID) {
+			return;
+		}
+		$mailAccount = $this->mapper->find($currentUserId, $accountId);
+		$this->mapper->delete($mailAccount);
+	}
+
+	/**
+	 * @param $newAccount
+	 * @return \OCA\Mail\Db\MailAccount
+	 */
+	public function save($newAccount) {
+		return $this->mapper->save($newAccount);
+	}
+
+	private function buildUnifiedAccount($userId) {
+		return new UnifiedAccount($this, $userId);
+	}
+}

--- a/lib/service/accountservice.php
+++ b/lib/service/accountservice.php
@@ -5,19 +5,22 @@ namespace OCA\Mail\Service;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
+use OCP\IL10N;
 
 class AccountService {
 
-	/**
-	 * @var \OCA\Mail\Db\MailAccountMapper
-	 */
+	/** @var \OCA\Mail\Db\MailAccountMapper */
 	private $mapper;
+
+	/** @var IL10N */
+	private $l10n;
 
 	/**
 	 * @param MailAccountMapper $mapper
 	 */
-	public function __construct($mapper) {
+	public function __construct(MailAccountMapper $mapper, IL10N $l10n) {
 		$this->mapper = $mapper;
+		$this->l10n = $l10n;
 	}
 
 	/**
@@ -69,6 +72,6 @@ class AccountService {
 	}
 
 	private function buildUnifiedAccount($userId) {
-		return new UnifiedAccount($this, $userId);
+		return new UnifiedAccount($this, $userId, $this->l10n);
 	}
 }

--- a/lib/service/iaccount.php
+++ b/lib/service/iaccount.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OCA\Mail\Service;
+
+
+interface IAccount {
+	/**
+	 * @return array
+	 */
+	public function getConfiguration();
+
+	/**
+	 * @return array
+	 * TODO: function name is :hankey:
+	 */
+	public function getListArray();
+
+	/**
+	 * @param $folderId
+	 * @return IMailbox
+	 */
+	public function getMailbox($folderId);
+
+	/**
+	 * @return string
+	 */
+	public function getEmail();
+
+	/**
+	 * @param string $folderId
+	 * @param int $messageId
+	 */
+	public function deleteMessage($folderId, $messageId);
+
+	/**
+	 * @param string[] $query
+	 * @return array
+	 */
+	public function getChangedMailboxes($query);
+
+	/**
+	 * @return IMailBox
+	 */
+	public function getInbox();
+
+	/**
+	 * @return int
+	 */
+	public function getId();
+
+}

--- a/lib/service/imailbox.php
+++ b/lib/service/imailbox.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Attachment;
+use OCA\Mail\Message;
+
+interface IMailBox {
+
+	/**
+	 * @return string
+	 */
+	public function getFolderId();
+
+	/**
+	 * @param int $from
+	 * @param int $count
+	 * @param string|\Horde_Imap_Client_Search_Query $filter
+	 * @return array
+	 */
+	public function getMessages($from, $count, $filter);
+
+	/**
+	 * @return string
+	 */
+	public function getSpecialRole();
+
+	/**
+	 * @param int $id
+	 * @return Message
+	 */
+	public function getMessage($id);
+
+	/**
+	 * @param int $messageId
+	 * @param string $attachmentId
+	 * @return Attachment
+	 */
+	public function getAttachment($messageId, $attachmentId);
+
+	/**
+	 * @param int $messageId
+	 * @param string $flag
+	 * @param mixed $value
+	 */
+	public function setMessageFlag($messageId, $flag, $value);
+
+	/**
+	 * @return array
+	 */
+	public function getStatus();
+}

--- a/lib/service/imailbox.php
+++ b/lib/service/imailbox.php
@@ -49,4 +49,5 @@ interface IMailBox {
 	 * @return array
 	 */
 	public function getStatus();
+
 }

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -2,6 +2,8 @@
 
 namespace OCA\Mail\Service;
 
+use OCP\IL10N;
+
 class UnifiedAccount implements IAccount {
 
 	const ID = -1;
@@ -9,10 +11,20 @@ class UnifiedAccount implements IAccount {
 	/** @var AccountService */
 	private $accountService;
 
-	public function __construct(AccountService $accountService, $userId) {
+	/** @var IL10N */
+	private $l10n;
+
+	/**
+	 * @param AccountService $accountService
+	 * @param string $userId
+	 * @param IL10N $l10n
+	 */
+	public function __construct(AccountService $accountService, $userId, IL10N $l10n) {
 		$this->accountService = $accountService;
 		$this->userId = $userId;
+		$this->l10n = $l10n;
 	}
+
 	/**
 	 * @return array
 	 */
@@ -38,7 +50,7 @@ class UnifiedAccount implements IAccount {
 	}
 
 	private function buildInbox() {
-		$displayName = 'All inboxes';
+		$displayName = $this->l10n->t('All inboxes');
 		$id = 'all-inboxes';
 
 		$allAccounts = $this->accountService->findByUserId($this->userId);

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -97,10 +97,15 @@ class UnifiedAccount implements IAccount {
 
 	/**
 	 * @param string $folderId
-	 * @param int $messageId
+	 * @param string $messageId
 	 */
 	public function deleteMessage($folderId, $messageId) {
-		// TODO: Implement deleteMessage() method.
+		$data = json_decode(base64_decode($messageId), true);
+		$account = $this->accountService->find($this->userId, $data[0]);
+		$inbox = $account->getInbox();
+		$messageId = $data[1];
+
+		$account->deleteMessage($inbox->getFolderId(), $messageId);
 	}
 
 	/**

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace OCA\Mail\Service;
+
+class UnifiedAccount implements IAccount {
+
+	const ID = -1;
+
+	/** @var AccountService */
+	private $accountService;
+
+	public function __construct(AccountService $accountService, $userId) {
+		$this->accountService = $accountService;
+		$this->userId = $userId;
+	}
+	/**
+	 * @return array
+	 */
+	public function getConfiguration() {
+		return [
+			'accountId' => UnifiedAccount::ID,
+		];
+	}
+
+	/**
+	 * @return array
+	 * TODO: function name is :hankey:
+	 */
+	public function getListArray() {
+		$inbox = $this->buildInbox();
+		return [
+			'id'             => UnifiedAccount::ID,
+			'email'          => '',
+			'folders'        => [$inbox],
+			'specialFolders' => [],
+			'delimiter' => '.',
+		];
+	}
+
+	private function buildInbox() {
+		$displayName = 'All inboxes';
+		$id = 'all-inboxes';
+
+		$allAccounts = $this->accountService->findByUserId($this->userId);
+		$unreadCounts = array_map(function($account) {
+			/** @var IAccount $account */
+			$inbox = $account->getInbox();
+			if (is_null($inbox)) {
+				return 0;
+			}
+			$status = $inbox->getStatus();
+			return isset($status['unseen']) ? $status['unseen'] : 0;
+		}, $allAccounts);
+
+		$unseen = array_sum($unreadCounts);
+		return [
+			'id' => base64_encode($id),
+			'parent' => null,
+			'name' => $displayName,
+			'specialRole' => 'inbox',
+			'unseen' => $unseen,
+			'total' => 100,
+			'isEmpty' => false,
+			'accountId' => UnifiedAccount::ID,
+			'noSelect' => false,
+			'uidvalidity' => 0,
+			'uidnext' => 0,
+			'delimiter' => '.'
+		];	}
+
+	/**
+	 * @param $folderId
+	 * @return IMailBox
+	 */
+	public function getMailbox($folderId) {
+		return new UnifiedMailbox($this->accountService, $this->userId);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEmail() {
+		return '';
+	}
+
+	/**
+	 * @param string $folderId
+	 * @param int $messageId
+	 */
+	public function deleteMessage($folderId, $messageId) {
+		// TODO: Implement deleteMessage() method.
+	}
+
+	/**
+	 * @param string[] $query
+	 * @return array
+	 */
+	public function getChangedMailboxes($query) {
+		return [];
+	}
+
+	/**
+	 * @return IMailBox
+	 */
+	public function getInbox() {
+		return null;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId() {
+		return UnifiedAccount::ID;
+	}
+}

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -50,7 +50,7 @@ class UnifiedAccount implements IAccount {
 	}
 
 	private function buildInbox() {
-		$displayName = $this->l10n->t('All inboxes');
+		$displayName = (string)$this->l10n->t('All inboxes');
 		$id = 'all-inboxes';
 
 		$allAccounts = $this->accountService->findByUserId($this->userId);

--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -77,33 +77,49 @@ class UnifiedMailbox implements IMailBox {
 	 * @return Message
 	 */
 	public function getMessage($messageId, $loadHtmlMessageBody = false) {
-		$data = json_decode(base64_decode($messageId), true);
-		$account = $this->accountService->find($this->userId, $data[0]);
-		return $account->getInbox()->getMessage($data[1], $loadHtmlMessageBody);
+		/** @var IMailBox $inbox */
+		list($inbox, $messageId) = $this->resolve($messageId);
+		return $inbox->getMessage($messageId, $loadHtmlMessageBody);
 	}
 
 	/**
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @param string $attachmentId
 	 * @return Attachment
 	 */
 	public function getAttachment($messageId, $attachmentId) {
-		// TODO: Implement getAttachment() method.
+		/** @var IMailBox $inbox */
+		list($inbox, $messageId) = $this->resolve($messageId);
+		return $inbox->getAttachment($messageId, $attachmentId);
 	}
 
 	/**
-	 * @param int $messageId
+	 * @param string $messageId
 	 * @param string $flag
 	 * @param mixed $value
 	 */
 	public function setMessageFlag($messageId, $flag, $value) {
-		// TODO: Implement setMessageFlag() method.
+		/** @var IMailBox $inbox */
+		list($inbox, $messageId) = $this->resolve($messageId);
+		return $inbox->setMessageFlag($messageId, $flag, $value);
 	}
 
 	/**
 	 * @return array
 	 */
 	public function getStatus() {
-		// TODO: Implement getStatus() method.
+		return [];
+	}
+
+	/**
+	 * @param string $messageId
+	 * @return array
+	 */
+	private function resolve($messageId) {
+		$data = json_decode(base64_decode($messageId), true);
+		$account = $this->accountService->find($this->userId, $data[0]);
+		$inbox = $account->getInbox();
+		$messageId = $data[1];
+		return array($inbox, $messageId);
 	}
 }

--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -78,8 +78,13 @@ class UnifiedMailbox implements IMailBox {
 	 */
 	public function getMessage($messageId, $loadHtmlMessageBody = false) {
 		/** @var IMailBox $inbox */
-		list($inbox, $messageId) = $this->resolve($messageId);
-		return $inbox->getMessage($messageId, $loadHtmlMessageBody);
+		/** @var IAccount $account */
+		list($inbox, $messageId, $account) = $this->resolve($messageId);
+		/** @var Message $message */
+		$message = $inbox->getMessage($messageId, $loadHtmlMessageBody);
+		$message->setUid(base64_encode(json_encode([$account->getId(), $message->getUid()])));
+
+		return $message;
 	}
 
 	/**
@@ -120,6 +125,6 @@ class UnifiedMailbox implements IMailBox {
 		$account = $this->accountService->find($this->userId, $data[0]);
 		$inbox = $account->getInbox();
 		$messageId = $data[1];
-		return array($inbox, $messageId);
+		return array($inbox, $messageId, $account);
 	}
 }

--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -73,13 +73,13 @@ class UnifiedMailbox implements IMailBox {
 	}
 
 	/**
-	 * @param int $id
+	 * @param string $messageId
 	 * @return Message
 	 */
-	public function getMessage($id) {
-		$data = json_decode(base64_decode($id), true);
+	public function getMessage($messageId, $loadHtmlMessageBody = false) {
+		$data = json_decode(base64_decode($messageId), true);
 		$account = $this->accountService->find($this->userId, $data[0]);
-		return $account->getInbox()->getMessage($data[1]);
+		return $account->getInbox()->getMessage($data[1], $loadHtmlMessageBody);
 	}
 
 	/**

--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Attachment;
+use OCA\Mail\Message;
+
+class UnifiedMailbox implements IMailBox {
+
+	public function __construct(AccountService $accountService, $userId) {
+		$this->accountService = $accountService;
+		$this->userId = $userId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFolderId() {
+		// TODO: Implement getFolderId() method.
+	}
+
+	/**
+	 * @param int $from
+	 * @param int $count
+	 * @param string|\Horde_Imap_Client_Search_Query $filter
+	 * @return array
+	 */
+	public function getMessages($from, $count, $filter) {
+		$allAccounts = $this->accountService->findByUserId($this->userId);
+		$allMessages = array_map(function($account) use ($from, $count, $filter) {
+			/** @var IAccount $account */
+			if ($account->getId() === UnifiedAccount::ID) {
+				return [];
+			}
+			$inbox = $account->getInbox();
+			if (is_null($inbox)) {
+				return [];
+			}
+
+			$messages = $inbox->getMessages($from, $count, $filter);
+			$messages = array_map(function($message) use ($account) {
+				$message['id'] = base64_encode(json_encode([$account->getId(), $message['id']]));
+				return $message;
+			}, $messages);
+
+			return $messages;
+		}, $allAccounts);
+
+		$allMessages = array_reduce($allMessages, function($a, $b) {
+			if (is_null($a)) {
+				return $b;
+			}
+			if (is_null($b)) {
+				return $a;
+			}
+			return array_merge($a, $b);
+		});
+
+		// sort by time
+		usort($messages, function($a, $b) {
+			return $a['dateInt'] < $b['dateInt'];
+		});
+
+		return $allMessages;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSpecialRole() {
+		return 'inbox';
+	}
+
+	/**
+	 * @param int $id
+	 * @return Message
+	 */
+	public function getMessage($id) {
+		$data = json_decode(base64_decode($id), true);
+		$account = $this->accountService->find($this->userId, $data[0]);
+		return $account->getInbox()->getMessage($data[1]);
+	}
+
+	/**
+	 * @param int $messageId
+	 * @param string $attachmentId
+	 * @return Attachment
+	 */
+	public function getAttachment($messageId, $attachmentId) {
+		// TODO: Implement getAttachment() method.
+	}
+
+	/**
+	 * @param int $messageId
+	 * @param string $flag
+	 * @param mixed $value
+	 */
+	public function setMessageFlag($messageId, $flag, $value) {
+		// TODO: Implement setMessageFlag() method.
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getStatus() {
+		// TODO: Implement getStatus() method.
+	}
+}

--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -40,6 +40,7 @@ class UnifiedMailbox implements IMailBox {
 			$messages = $inbox->getMessages($from, $count, $filter);
 			$messages = array_map(function($message) use ($account) {
 				$message['id'] = base64_encode(json_encode([$account->getId(), $message['id']]));
+				$message['accountMail'] = $account->getEmail();
 				return $message;
 			}, $messages);
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -37,12 +37,18 @@ script('mail', 'jquery-visibility');
 	</li>
 </script>
 <script id="mail-account-template" type="text/x-handlebars-template">
+	{{#if email}}
+	<div class="mail-account-color" style="background-color: {{accountColor email}}"></div>
+	{{/if}}
 	<h2 class="mail-account-email" title="{{email}}">{{email}}</h2>
 	<ul id="mail_folders" class="mail_folders with-icon" data-account_id="{{id}}">
 	</ul>
 </script>
 <script id="mail-messages-template" type="text/x-handlebars-template">
 	<div class="mail_message_summary {{#if flags.unseen}}unseen{{/if}} {{#if active}}active{{/if}}" data-message-id="{{id}}">
+		{{#if accountMail}}
+		<div class="mail-message-account-color" style="background-color: {{accountColor accountMail}}"></div>
+		{{/if}}
 		<div class="mail-message-header">
 			<div class="sender-image">
 				{{#if senderImage}}


### PR DESCRIPTION
Issues left:

* [x] It’s not possible to delete or star mails – neither in the unified inbox nor in the individual ones (only starring is possible in the individual ones)
* [ ] We need to not show the color of the account when there is only one. Simply do not set the background-color of `.mail-account-color`
* [x] And: When writing a new message, the first entry in the dropdown is `from <>` – I suppose that is because we think the unified inbox is an account.
* [x] sending mails does not work anymore: `Call to undefined method: OCA\\ … getOutboundPassword at account.php line 244`
* [ ] On new mails, the list is not automatically refreshed
* [x] The first message opened / highlighted in the unified inbox is the latest of the first account, not the latest overall.
* [ ] When clicking »load more« the list jump-scrolls to the top as soon as more emails are loaded.
* [x] In the unified inbox, only emails from the first inbox are loaded. When clicking another mail, it shows `Error loading message. No matching entry found`