### PR TITLE
fix reply fields overlapping message header bar

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -496,6 +496,7 @@
 	height: 90px;
 	width: 50%;
 	background-color: rgba(255,255,255,.9);
+	z-index: 100;
 }
 
 #mail-message-header h2,


### PR DESCRIPTION
Previously when you had a large reply box and scrolled down, the reply input boxes would overlay the fixed header bar. This fixes that.

Please review @aidanamavi @colmoneill @irgendwie :)