### PR TITLE
resolved message fetcher timing issues

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -326,10 +326,8 @@ var Mail = {
 					// Stop previous fetcher
 					clearInterval(timer);
 
-					// Stop any ajax message requests
-					if (Mail.State.messageLoading !== null) {
-						Mail.State.messageLoading.abort();
-					}
+					// Clear waiting queue
+					queue.length = 0;
 
 					// Start again
 					this.start();


### PR DESCRIPTION
The background message fetcher didn't stop fetching messages of the previous
folder when the folder was changed. This caused 404s because the message
IDs and folder IDs did not match