### PR TITLE
enable HTTP caching for HTML message bodies

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -13,7 +13,6 @@
 namespace OCA\Mail\Controller;
 
 use Horde_Imap_Client;
-use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Http\AttachmentDownloadResponse;
 use OCA\Mail\Http\HtmlResponse;
 use OCA\Mail\Service\AccountService;
@@ -59,7 +58,7 @@ class MessagesController extends Controller {
 	/**
 	 * @param string $appName
 	 * @param \OCP\IRequest $request
-	 * @param MailAccountMapper $mapper
+	 * @param AccountService $accountService
 	 * @param $currentUserId
 	 * @param $userFolder
 	 * @param $contactsIntegration
@@ -87,15 +86,16 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param int $from
 	 * @param int $to
 	 * @param string $filter
 	 * @return JSONResponse
 	 */
-	public function index($from=0, $to=20, $filter=null) {
-		$mailBox = $this->getFolder();
+	public function index($accountId, $folderId, $from=0, $to=20, $filter=null) {
+		$mailBox = $this->getFolder($accountId, $folderId);
 
-		$folderId = $mailBox->getFolderId();
 		$this->logger->debug("loading messages $from to $to of folder <$folderId>");
 
 		$json = $mailBox->getMessages($from, $to-$from+1, $filter);
@@ -125,15 +125,14 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param mixed $id
 	 * @return JSONResponse
 	 */
-	public function show($id) {
-		$accountId = $this->params('accountId');
-		$folderId = $this->params('folderId');
-		$mailBox = $this->getFolder();
-
-		$account = $this->getAccount();
+	public function show($accountId, $folderId, $id) {
+		$mailBox = $this->getFolder($accountId, $folderId);
+		$account = $this->getAccount($accountId);
 		try {
 			$m = $mailBox->getMessage($id);
 		} catch (DoesNotExistException $ex) {
@@ -160,12 +159,14 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param string $messageId
-	 * @return JSONResponse
+	 * @return \OCA\Mail\Http\HtmlResponse
 	 */
-	public function getHtmlBody($messageId) {
+	public function getHtmlBody($accountId, $folderId, $messageId) {
 		try {
-			$mailBox = $this->getFolder();
+			$mailBox = $this->getFolder($accountId, $folderId);
 
 			$m = $mailBox->getMessage($messageId, true);
 			$html = $m->getHtmlBody();
@@ -184,6 +185,10 @@ class MessagesController extends Controller {
 				$htmlResponse->setContentSecurityPolicy($policy);
 			}
 
+			// Enable caching
+			$htmlResponse->cacheFor(60 * 60);
+			$htmlResponse->addHeader('Pragma', 'cache');
+
 			return $htmlResponse;
 		} catch(\Exception $ex) {
 			return new TemplateResponse($this->appName, 'error', ['message' => $ex->getMessage()], 'none');
@@ -194,12 +199,14 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
+	 * @param int $accountId
+	 * @param string folderId
 	 * @param string $messageId
 	 * @param string $attachmentId
 	 * @return AttachmentDownloadResponse
 	 */
-	public function downloadAttachment($messageId, $attachmentId) {
-		$mailBox = $this->getFolder();
+	public function downloadAttachment($accountId, $folderId, $messageId, $attachmentId) {
+		$mailBox = $this->getFolder($accountId, $folderId);
 
 		$attachment = $mailBox->getAttachment($messageId, $attachmentId);
 
@@ -213,13 +220,15 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param string $messageId
 	 * @param string $attachmentId
 	 * @param string $targetPath
 	 * @return JSONResponse
 	 */
-	public function saveAttachment($messageId, $attachmentId, $targetPath) {
-		$mailBox = $this->getFolder();
+	public function saveAttachment($accountId, $folderId, $messageId, $attachmentId, $targetPath) {
+		$mailBox = $this->getFolder($accountId, $folderId);
 
 		$attachmentIds = [$attachmentId];
 		if($attachmentId === 0) {
@@ -252,12 +261,14 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param string $messageId
 	 * @param boolean $starred
 	 * @return JSONResponse
 	 */
-	public function toggleStar($messageId, $starred) {
-		$mailBox = $this->getFolder();
+	public function toggleStar($accountId, $folderId, $messageId, $starred) {
+		$mailBox = $this->getFolder($accountId, $folderId);
 
 		$mailBox->setMessageFlag($messageId, Horde_Imap_Client::FLAG_FLAGGED, !$starred);
 
@@ -267,13 +278,15 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @param string $id
 	 * @return JSONResponse
 	 */
-	public function destroy($id) {
+	public function destroy($accountId, $folderId, $id) {
 		try {
-			$account = $this->getAccount();
-			$account->deleteMessage(base64_decode($this->params('folderId')), $id);
+			$account = $this->getAccount($accountId);
+			$account->deleteMessage(base64_decode($folderId), $id);
 			return new JSONResponse();
 
 		} catch (DoesNotExistException $e) {
@@ -282,20 +295,21 @@ class MessagesController extends Controller {
 	}
 
 	/**
+	 * @param int $accountId
 	 * @return \OCA\Mail\Service\IAccount
 	 */
-	private function getAccount() {
-		$accountId = $this->params('accountId');
+	private function getAccount($accountId) {
 		return $this->accountService->find($this->currentUserId, $accountId);
 	}
 
 	/**
+	 * @param int $accountId
+	 * @param string $folderId
 	 * @return IMailBox
 	 */
-	private function getFolder() {
-		$account = $this->getAccount();
-		$folderId = base64_decode($this->params('folderId'));
-		return $account->getMailbox($folderId);
+	private function getFolder($accountId, $folderId) {
+		$account = $this->getAccount($accountId);
+		return $account->getMailbox(base64_decode($folderId));
 	}
 
 	/**

--- a/tests/controller/messagescontrollertest.php
+++ b/tests/controller/messagescontrollertest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * ownCloud - Mail app
+ *
+ * @author Christoph Wurst
+ * @copyright 2015 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use OCA\Mail\Controller\MessagesController;
+
+/**
+ * Tests for lib/controller/messagescontroller
+ *
+ * @author Christoph Wurst
+ */
+class messagescontrollertest extends \Test\TestCase {
+
+	private $appName;
+	private $request;
+	private $accountService;
+	private $userId;
+	private $userFolder;
+	private $contactIntegration;
+	private $logger;
+	private $l10n;
+	private $controller;
+	private $account;
+	private $mailbox;
+	private $message;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->appName = 'mail';
+		$this->request = $this->getMockBuilder('\OCP\IRequest')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->accountService = $this->getMockBuilder('\OCA\Mail\Service\AccountService')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userId = 'john';
+		$this->userFolder = '/tmp/';
+		$this->request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->contactIntegration = $this->getMockBuilder('\OCA\Mail\Service\ContactsIntegration')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->logger = $this->getMockBuilder('\OCA\Mail\Service\Logger')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->l10n = $this->getMockBuilder('\OCA\Mail\Service\Logger')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->controller = new MessagesController(
+			$this->appName,
+			$this->request,
+			$this->accountService,
+			$this->userId,
+			$this->userFolder,
+			$this->contactIntegration,
+			$this->logger,
+			$this->l10n);
+
+		$this->account = $this->getMockBuilder('\OCA\Mail\Account')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->mailbox = $this->getMockBuilder('\OCA\Mail\Mailbox')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->message = $this->getMockBuilder('\OCA\Mail\Message')
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testGetHtmlBody() {
+		$accountId = 17;
+		$folderId = 'testfolder';
+		$messageId = 4321;
+
+		$this->accountService->expects($this->once())
+			->method('find')
+			->with($this->equalTo($this->userId), $this->equalTo($accountId))
+			->will($this->returnValue($this->account));
+		$this->account->expects($this->once())
+			->method('getMailbox')
+			->with($this->equalTo($folderId))
+			->will($this->returnValue($this->mailbox));
+		$this->mailbox->expects($this->once())
+			->method('getMessage')
+			->with($this->equalTo($messageId), $this->equalTo(true))
+			->will($this->returnValue($this->message));
+
+		$response = $this->controller->getHtmlBody($accountId, base64_encode($folderId), $messageId);
+
+		$this->assertInstanceOf('\OCA\Mail\Http\HtmlResponse', $response);
+		$headers = $response->getHeaders();
+		// Check for header existense
+		$this->assertTrue(array_key_exists('Cache-Control', $headers));
+		$this->assertTrue(array_key_exists('Pragma', $headers));
+
+		// Check header values
+		$this->assertSame($headers['Cache-Control'], 'max-age=3600, must-revalidate');
+		$this->assertSame($headers['Pragma'], 'cache');
+	}
+
+}


### PR DESCRIPTION
partially fixes #799

Firefox seems to ignore it for some reason, but Chrome caches message bodies as expected.

@LukasReschke @DeepDiver1975 @Xenopathic review please