### PR TITLE
fix PHPDoc parameter types for proper casting to bool/int

### DIFF
--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -134,7 +134,7 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param $accountId
+	 * @param int $accountId
 	 * @return JSONResponse
 	 */
 	public function show($accountId) {
@@ -159,7 +159,7 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param string $accountId
+	 * @param int $accountId
 	 * @return JSONResponse
 	 */
 	public function destroy($accountId) {
@@ -179,16 +179,16 @@ class AccountsController extends Controller {
 	 * @param string $emailAddress
 	 * @param string $password
 	 * @param string $imapHost
-	 * @param int    $imapPort
+	 * @param int $imapPort
 	 * @param string $imapSslMode
 	 * @param string $imapUser
 	 * @param string $imapPassword
 	 * @param string $smtpHost
-	 * @param int    $smtpPort
+	 * @param int $smtpPort
 	 * @param string $smtpSslMode
 	 * @param string $smtpUser
 	 * @param string $smtpPassword
-	 * @param bool   $autoDetect
+	 * @param bool $autoDetect
 	 * @return JSONResponse
 	 */
 	public function create($accountName, $emailAddress, $password,
@@ -261,16 +261,16 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int      $accountId
-	 * @param string   $folderId
-	 * @param string   $subject
-	 * @param string   $body
-	 * @param string   $to
-	 * @param string   $cc
-	 * @param string   $bcc
-	 * @param int|bool $draftUID
-	 * @param int      $messageId
-	 * @param mixed    $attachments
+	 * @param int $accountId
+	 * @param string $folderId
+	 * @param string $subject
+	 * @param string $body
+	 * @param string $to
+	 * @param string $cc
+	 * @param string $bcc
+	 * @param int $draftUID
+	 * @param int $messageId
+	 * @param mixed $attachments
 	 * @return JSONResponse
 	 */
 	public function send($accountId, $folderId, $subject, $body, $to, $cc,
@@ -382,13 +382,13 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 * 
-	 * @param int      $accountId
-	 * @param string   $subject
-	 * @param string   $body
-	 * @param string   $to
-	 * @param string   $cc
-	 * @param string   $bcc
-	 * @param int|null $uid
+	 * @param int $accountId
+	 * @param string $subject
+	 * @param string $body
+	 * @param string $to
+	 * @param string $cc
+	 * @param string $bcc
+	 * @param int $uid
 	 * @return JSONResponse
 	 */
 	public function draft($accountId, $subject, $body, $to, $cc, $bcc, $uid) {


### PR DESCRIPTION
@DeepDiver1975 @Nawuko please review

fixes #813 and replaces #814 

Additionally to ``$autoDetect``, also integer parameters like ``$imapPort`` are currently not being casted. This should be fixed with this PR