### PR TITLE
Prevent Firefox e10s to crash when registerProtocolHandler

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -567,8 +567,10 @@ var Mail = {
 				var url = window.location.protocol + '//' +
 					window.location.host +
 					OC.generateUrl('apps/mail/compose?uri=%s');
-				window.navigator
-					.registerProtocolHandler("mailto", url, "ownCloud Mail");
+				try {
+					window.navigator
+						.registerProtocolHandler("mailto", url, "ownCloud Mail");
+				} catch (e) {}
 			}
 
 			// setup messages view


### PR DESCRIPTION
Hello

Firefox e10s crash when it goes throught the registerProtocolHandler function.
The only workaround I found is a try catch around this function.

It's shows this if the fix isn't applied :

![mail - owncloud 2015-06-22 11-31-38](https://cloud.githubusercontent.com/assets/961976/8279178/74b00c7a-18d2-11e5-926c-affbe151608d.png)

Here is the complete error : 

```
NS_ERROR_XPC_JAVASCRIPT_ERROR_WITH_DETAILS: [JavaScript Error: "aWindow.QueryInterface is not a function" {file: "resource://gre/modules/PrivateBrowsingUtils.jsm" line: 49}]'[JavaScript Error: "aWindow.QueryInterface is not a function" {file: "resource://gre/modules/PrivateBrowsingUtils.jsm" line: 49}]' when calling method: [nsIWebContentHandlerRegistrar::registerProtocolHandler]
```

Thank you.