### PR TITLE
Unread/read status syncing, message syncing, and infinite scrolling.

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,6 +32,14 @@ $app->registerRoutes($this,
 				'url' => '/accounts/{accountId}/folders/{folderId}/messages/{messageId}/toggleStar',
 				'verb' => 'POST'],
 			[
+				'name' => 'messages#toggleUnseen',
+				'url' => '/accounts/{accountId}/folders/{folderId}/messages/{messageId}/toggleUnseen',
+				'verb' => 'POST'],
+			[
+				'name' => 'messages#getUnseenCount',
+				'url' => '/accounts/{accountId}/folders/{folderId}/getUnseenCount',
+				'verb' => 'POST'],
+			[
 				'name' => 'proxy#redirect',
 				'url' => '/redirect',
 				'verb' => 'GET'],

--- a/css/mail.css
+++ b/css/mail.css
@@ -224,20 +224,16 @@
 	overflow-x: hidden;
 	overflow-y: auto;
 }
-#load-new-mail-messages,
 #load-more-mail-messages {
 	display: none;
-	margin: 10px auto;
-	padding: 10px 10px 6px;
-}
-#load-more-mail-messages {
-	margin-bottom: 250px;
-}
-/* TODO: put this in core icons.css as general rule for buttons with icons */
-#load-new-mail-messages.icon-loading-small,
-#load-more-mail-messages.icon-loading-small {
-	padding-left: 32px;
-	background-position: 9px center;
+	height: 68px;
+	border-top: 1px solid #eee;
+	-webkit-box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
+	-moz-box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
+	box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
+	text-align: center;
+	line-height: 68px;
+	font-size: 16px;
 }
 
 .mail-message-header {

--- a/css/mail.css
+++ b/css/mail.css
@@ -228,9 +228,6 @@
 	display: none;
 	height: 68px;
 	border-top: 1px solid #eee;
-	-webkit-box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
-	-moz-box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
-	box-shadow: inset 0 4px 9px -6px rgba(0,0,0,.8);
 	text-align: center;
 	line-height: 68px;
 	font-size: 16px;

--- a/js/mail.js
+++ b/js/mail.js
@@ -585,9 +585,6 @@ var Mail = {
 			});
 			Mail.State.folderView.render();
 
-			Mail.State.folderView.listenTo(Mail.UI.messageView, 'change:unseen',
-				Mail.State.folderView.changeUnseen);
-
 			// request permissions
 			if (typeof Notification !== 'undefined') {
 				Notification.requestPermission();
@@ -597,6 +594,11 @@ var Mail = {
 				OC.Plugins.register('OCA.Search', Mail.Search);
 			}
 
+			/**
+			 * Checks and loads any new messages and changes to the current folder.
+			 * @todo combine this with the checkForNotifications method.
+			 * @todo leadMessages needs to update the unseen folder counter.
+			 */
 			setInterval(Mail.BackGround.checkForNotifications, 5*60*1000);
 			this.loadAccounts();
 		};
@@ -700,8 +702,6 @@ var Mail = {
 			$('#folders').removeClass('hidden');
 			$('#mail-setup').addClass('hidden');
 
-			$('#load-new-mail-messages').hide();
-			$('#load-more-mail-messages').hide();
 			$('#emptycontent').hide();
 
 			if (noSelect) {
@@ -729,29 +729,22 @@ var Mail = {
 							if (jsondata.length > 0) {
 								Mail.UI.addMessages(jsondata);
 
+								// Load once to initiate object accessability outside of Backbone.
+								Mail.UI.messageView.loadMessages('newFolder');
+
 								// Fetch first 10 messages in background
 								var first10 = Mail.State.messageView.collection.first(10);
 								_.each(first10, function (message) {
 									Mail.BackGround.messageFetcher.push(message.id);
 								});
 
+								// Load the first message in the message list.
 								var messageId = Mail.State.messageView.collection.first().get('id');
 								Mail.UI.loadMessage(messageId);
-								// Show 'Load More' button if there are
-								// more messages than the pagination limit
-								if (jsondata.length > 20) {
-									$('#load-more-mail-messages')
-										.fadeIn()
-										.css('display', 'block');
-								}
 							} else {
 								$('#emptycontent').show();
 								$('#mail-message').removeClass('icon-loading');
 							}
-							$('#load-new-mail-messages')
-								.fadeIn()
-								.css('display', 'block')
-								.prop('disabled', false);
 
 						},
 						error: function(textStatus) {
@@ -963,8 +956,6 @@ var Mail = {
 				mailBody
 					.html(html)
 					.removeClass('icon-loading');
-
-				Mail.UI.messageView.setMessageFlag(messageId, 'unseen', false);
 
 				// HTML mail rendering
 				$('iframe').load(function() {
@@ -1195,6 +1186,35 @@ var Mail = {
 
 $(document).ready(function() {
 	Mail.UI.initializeInterface();
+
+	// Enables infinite scroll ability.
+	setInterval(function() {
+
+		// Element identifies the element we want to trigger our loading on.
+		//var element = $('.mail_message_summary:nth-last-child(1)');
+		var element = $('#load-more-mail-messages');
+		var outerHeight = element.outerHeight();
+		var offset = element.offset();
+		var scrollLength = $('#mail_messages').scrollTop();
+		var screenHeight = $(document).height();
+		var messageListHeight = scrollLength + offset.top + outerHeight;
+
+		if ((scrollLength + screenHeight) >= messageListHeight) {
+			Mail.UI.messageView.loadMessages('addMore');
+		}
+
+	}, 1000);
+
+	/**
+	 * Checks and loads any new messages and changes to the current folder.
+	 * @todo combine this with the checkForNotifications method.
+	 */
+	setInterval((function() {
+		// Begin the loop.
+		return function() {
+			Mail.UI.messageView.loadMessages();
+		};
+	})(), 10*1000);
 
 	// auto detect button handling
 	$('#auto_detect_account').click(function(event) {

--- a/js/send-mail.js
+++ b/js/send-mail.js
@@ -122,7 +122,8 @@ $(function() {
 			},
 			type: 'POST',
 			success:function() {
-				Mail.UI.messageView.setMessageFlag(messageId, 'answered', true);
+				// Reload the message list to display the answered flag.
+				Mail.UI.messageView.loadMessages();
 				OC.Notification.showTemporary(t('mail', 'Message sent!'));
 
 				// close reply

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -300,15 +300,12 @@ views.Messages = Backbone.Marionette.CompositeView.extend({
 		if (settings === 'addMore' && element.is(':hidden')) {
 			return;
 		}
-		// Set the default class.
-		element.addClass('icon-download');
+		// Loading feedback
+		element.addClass('icon-loading');
 		if (settings === 'addMore'){
 			// Retrieve the next 20 older messages.
 			from = this.collection.size();
 			to = from + 20;
-			// Display feedback.
-			element.removeClass('icon-download');
-			element.addClass('icon-loading');
 		} else  {
 			// Refresh the message list to display any updates.
 			from = 0;
@@ -367,7 +364,7 @@ views.Messages = Backbone.Marionette.CompositeView.extend({
 					if (settings === 'addMore') {
 						// Display error message at the bottom message list.
 						element
-							.removeClass('icon-loading').removeClass('icon-download')
+							.removeClass('icon-loading')
 							.html(t('mail', 'Cannot communicate with mail server.'));
 					} else {
 						// Display it at the top of the ownCloud page.
@@ -378,8 +375,7 @@ views.Messages = Backbone.Marionette.CompositeView.extend({
 				},
 				complete: function() {
 					// Set the element back to it's normal state.
-					element.removeClass('icon-loading');
-					element.addClass('icon-download');
+					element.addClass('icon-loading');
 				}
 			});
 	}

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -268,6 +268,36 @@ class MessagesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param string $messageId
+	 * @param boolean $unseen
+	 * @return JSONResponse
+	 */
+	public function toggleUnseen($messageId, $unseen) {
+		$mailBox = $this->getFolder();
+
+		$mailBox->setMessageFlag($messageId, Horde_Imap_Client::FLAG_SEEN, !$unseen);
+
+		return new JSONResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $accountId Defaults are POST parameters.
+	 * @param string $folderId Defaults are POST parameters.
+	 * @return JSONResponse
+	 */
+	public function getUnseenCount($accountId, $folderId) {
+
+		$mailBox = $this->getFolder();
+		$status = $mailBox->getStatus(\Horde_Imap_Client::STATUS_UNSEEN);
+
+		return new JSONResponse($status);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
 	 * @param string $id
 	 * @return JSONResponse
 	 */

--- a/templates/index.php
+++ b/templates/index.php
@@ -244,13 +244,12 @@ script('mail', 'jquery-visibility');
 	</div>
 </script>
 <script id="message-list-template" type="text/x-handlebars-template">
-	<input type="button" id="load-new-mail-messages" value="<?php p($l->t('Check messages …')); ?>">
 	<div id="emptycontent" style="display: none;">
 		<div class="icon-mail"></div>
 		<h2><?php p($l->t('No messages in this folder!')); ?></h2>
 	</div>
 	<div id="mail-message-list"></div>
-	<input type="button" id="load-more-mail-messages" value="<?php p($l->t('Load more …')); ?>">
+	<div id="load-more-mail-messages"></div>
 </script>
 <div id="app">
 	<div id="app-navigation" class="icon-loading">


### PR DESCRIPTION
Added event handler for message click to toggle the unseen flag.
Added syncing for the message unseen flag to the mail server.
Added unseen status fetcher for the Inbox folder.
Added message list syncing.
Added infinite scrolling message list with feedback.

Fixes #104	Pull to refresh & automatic update of messages
Fixes #499	Automatic lazy loading of more messages when scrolled to the end of the list
Fixes #633	"Check messages" should sync deleted messages as well.
Fixes #773	Detect flag changes and expunged messages
Fixes #830	Adds bug fixes addressed in this pull request
Fixes #803	On new mails, the list is not automatically refreshed
			The 'Check messages' button disappears once refreshing the message list has finished.
			When clicking »load more« the list jump-scrolls to the top as soon as more emails are loaded