### PR TITLE
unified inbox: respect 'count' parameter and return only the first 'count' messages

### DIFF
--- a/lib/service/unifiedmailbox.php
+++ b/lib/service/unifiedmailbox.php
@@ -62,6 +62,10 @@ class UnifiedMailbox implements IMailBox {
 			return $a['dateInt'] < $b['dateInt'];
 		});
 
+		if (count >= 0) {
+			$allMessages = array_slice($allMessages, 0, $count);
+		}
+
 		return $allMessages;
 	}
 


### PR DESCRIPTION
@DeepDiver1975 @aidanamavi @Xenopathic review please

partially fixes #803