### PR TITLE
delete previous drafts if the currently composed message is an empty …

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -294,13 +294,16 @@ class MessagesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function destroy($accountId, $folderId, $id) {
+		$this->logger->debug("deleting message <$id> of folder <$folderId>, account <$accountId>");
 		try {
 			$account = $this->getAccount($accountId);
 			$account->deleteMessage(base64_decode($folderId), $id);
 			return new JSONResponse();
 
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse();
+			$this->logger->error("could not delete message <$id> of folder <$folderId>, "
+				. "account <$accountId> because it does not exist");
+			return new JSONResponse([], 404);
 		}
 	}
 


### PR DESCRIPTION
…message

partially fixes #735

This doesn't work with the unified inbox, because the DELETE route for messages doesn't handle the special ``-1`` account ID. I'll try to fix that in 0.3 by creating the unified inbox client-side (Backbone).

@irgendwie @jancborchardt review please :)