### PR TITLE
replace message list cache on reload

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -546,6 +546,7 @@ var Mail = {
 			options = options || {};
 			var defaults = {
 				cache: false,
+				replace: false, // Replace cached folder list
 				force: false,
 				onSuccess: function() {},
 				onError: function() {},
@@ -581,7 +582,7 @@ var Mail = {
 						filter: options.filter
 					},
 					success: function(messages) {
-						if (options.cache) {
+						if (options.replace || options.cache) {
 							Mail.Cache.addMessageList(accountId, folderId, messages);
 						}
 						options.onSuccess(messages, false);

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -274,6 +274,8 @@ views.Messages = Backbone.Marionette.CompositeView.extend({
 				to: from + 20,
 				query: this.filterCriteria ? this.filterCriteria.text : null,
 				force: true,
+				// Replace cached message list on reload
+				replace: reload,
 				onSuccess: function (jsondata) {
 					if (reload){
 						self.collection.reset();


### PR DESCRIPTION
@jancborchardt please test if this fixes the caching errors you noticed (messages still being shown after they have been deleted)