### PR TITLE
duplicate core js.js getScrollBarWidth for older oc releases

### DIFF
--- a/js/views/helper.js
+++ b/js/views/helper.js
@@ -94,6 +94,37 @@ $(document).ready(function() {
 		}
 	});
 
+	//duplicate getScrollBarWidth function from core js.js
+	//TODO: remove once OC 8.0 support has been dropped
+	window.getScrollBarWidth = window.getScrollBarWidth || function() {
+		var inner = document.createElement('p');
+		inner.style.width = "100%";
+		inner.style.height = "200px";
+
+		var outer = document.createElement('div');
+		outer.style.position = "absolute";
+		outer.style.top = "0px";
+		outer.style.left = "0px";
+		outer.style.visibility = "hidden";
+		outer.style.width = "200px";
+		outer.style.height = "150px";
+		outer.style.overflow = "hidden";
+		outer.appendChild (inner);
+
+		document.body.appendChild (outer);
+		var w1 = inner.offsetWidth;
+		outer.style.overflow = 'scroll';
+		var w2 = inner.offsetWidth;
+		if(w1 === w2) {
+			w2 = outer.clientWidth;
+		}
+
+		document.body.removeChild (outer);
+
+		return (w1 - w2);
+	};
+	//END TODO
+
 	// adjust controls/header bar width
 	window.adjustControlsWidth = function() {
 		if($('#mail-message-header').length) {


### PR DESCRIPTION
fixes #915

@rakshazi please check if this fixes the issue you reported