### PR TITLE
Fix: New mails sent from unified inbox

### DIFF
--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -333,7 +333,7 @@ views.Composer = Backbone.View.extend({
 				});
 
 				this.accountId    = account.accountId;
-				options.accountId = account.accountId; 
+				options.accountId = account.accountId;
 			} else {
 				options.messageId = this.messageId;
 				options.folderId = this.folderId;

--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -320,7 +320,7 @@ views.Composer = Backbone.View.extend({
 		if (this.isReply()) {
 			// the account-id is not available when replying from unified inbox
 			// we get the account-id by the account mail address from the message
-			if (this.accountId == -1) {
+			if (this.accountId === -1) {
 				var account = null;
  
 				var messageViewObject = Mail.State.messageView.collection.get({id: this.messageId});

--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -262,6 +262,11 @@ views.Composer = Backbone.View.extend({
 		newMessageSend.prop('disabled', true);
 		newMessageSend.val(t('mail', 'Sending …'));
 
+		// if available get account from drop-down list
+		if (this.$('.mail-account').length > 0) {
+			this.accountId = this.$('.mail-account').find(":selected").val();
+		}
+
 		// send the mail
 		var _this = this;
 		var options = {
@@ -313,8 +318,26 @@ views.Composer = Backbone.View.extend({
 		};
 
 		if (this.isReply()) {
-			options.messageId = this.messageId;
-			options.folderId = this.folderId;
+			// the account-id is not available when replying from unified inbox
+			// we get the account-id by the account mail address from the message
+			if (this.accountId == -1) {
+				var account = null;
+ 
+				var messageViewObject = Mail.State.messageView.collection.get({id: this.messageId});
+				var accountMail = messageViewObject.attributes.accountMail;
+				Mail.State.accounts.some(function (obj) {
+					if (obj.emailAddress === accountMail) {
+						account = obj;
+						return true;
+					}
+				});
+
+				this.accountId    = account.accountId;
+				options.accountId = account.accountId; 
+			} else {
+				options.messageId = this.messageId;
+				options.folderId = this.folderId;
+			}
 		}
 
 		this.submitCallback(this.accountId, this.getMessage(), options);


### PR DESCRIPTION
Fixes #921 

Here is my second attempt to fix this nasty dirty little thing. It feels dirty, drove me nuts and made me crying. I had to dig deeper than I wanted and to be honest I did't understand most of the things I saw :-)

To make replying from the unified inbox work I had to do some digging in the available objects to get the account id. When replying from the unified inbox I had to exclude ***options.messageId*** and ***options.folderId*** otherwise an Exception was thrown: ***Horde_Imap_Client_Exception, Message: Could not open mailbox "all-inboxes", Code:200***.
I'am not really satisfied with this approach but I don't know better as the whole thing is currently a miracle for me.

I think i've tested every posible combination and everything worked for me.

Please review carefully @jancborchardt  @ChristophWurst  and if you come to the conclusion that this is a single piece of rubbish please throw it away!