### PR TITLE
Replace tipsy with tooltip

### DIFF
--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -124,6 +124,8 @@ views.Composer = Backbone.View.extend({
 			replyCc: options.data.replyCc,
 			replyCcList: options.data.replyCcList
 		});
+		
+		$('.tipsy-mailto').tipsy({gravity:'n', live:true});
 
 		this.$el.html(html);
 

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -2,9 +2,6 @@
 
 var views = views || {};
 
-$('.action.delete').tipsy({gravity:'e', live:true});
-$('.tipsy-mailto').tipsy({gravity:'n', live:true});
-
 views.Message = Backbone.Marionette.ItemView.extend({
 
 	template: "#mail-messages-template",
@@ -37,6 +34,8 @@ views.Message = Backbone.Marionette.ItemView.extend({
 				$(a).imageplaceholder(displayName, displayName);
 			});
 		}
+		
+		$('.action.delete').tipsy({gravity:'e', live:true});
 	},
 
 	toggleMessageStar: function(event) {

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -91,7 +91,9 @@ views.Message = Backbone.Marionette.ItemView.extend({
 			}
 			// manually trigger mouseover event for current mouse position
 			// in order to create a tipsy for the next message if needed
-			$(document.elementFromPoint(event.clientX, event.clientY)).trigger('mouseover');
+			if(event.clientX) {
+			       $(document.elementFromPoint(event.clientX, event.clientY)).trigger('mouseover');
+			}
 		});
 
 		// really delete the message


### PR DESCRIPTION
As we moved from tipsy to tooltip (https://github.com/owncloud/core/pull/17075), I changed them for the mail app.

This resolves some issues / problems we had, like the recently https://github.com/owncloud/mail/issues/929, but also creates new problems:
- [x] weird transparency problems (the 'mail to' tooltips) @jancborchardt ideas?

Please review this and search for bugs! :+1: