### PR TITLE
cache new messages loaded in background

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -370,10 +370,16 @@ var Mail = {
 									Mail.UI.messageView.collection.add(f.messages);
 								}
 
+                                                                // Save new messages to the cached message list
+								var cachedList = Mail.Cache.getMessageList(f.accountId, f.id);
+								if (cachedList) {
+									cachedList = cachedList.concat(f.messages);
+									Mail.Cache.addMessageList(f.accountId, f.id, cachedList);
+								}
+
 								Mail.State.folderView.updateTitle();
 							});
 						}
-
 					}
 				);
 			});


### PR DESCRIPTION
This ensures messages are shown immediately when either clicking on a notification (which triggers a folder refresh and cached messages are shown first) or if you are in a folder other than the inbox with new messages and switch to the inbox (same reloading/caching issue).

possibly fixes issues reported in #919

@jancborchardt @irgendwie