### PR TITLE
remove new uncached messages from folder list cache

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -203,14 +203,14 @@ var Mail = {
 				if (message) {
 					// message exists in cache -> remove it
 					storage.remove(MessageCache.getMessagePath(accountId, folderId, messageId));
-					var messageList = this.getMessageList(accountId, folderId);
-					if (messageList) {
-						// message list is cached -> remove message from it
-						var newList = _.filter(messageList, function(message) {
-							return message.id !== messageId;
-						});
-						this.addMessageList(accountId, folderId, newList);
-					}
+				}
+				var messageList = this.getMessageList(accountId, folderId);
+				if (messageList) {
+					// message list is cached -> remove message from it
+					var newList = _.filter(messageList, function(message) {
+						return message.id !== messageId;
+					});
+					this.addMessageList(accountId, folderId, newList);
 				}
 			},
 			getMessageList: function(accountId, folderId) {


### PR DESCRIPTION
I guess this issue was introduced with my PR #937. The problem was that messages (message bodies to be precise) that haven't been cached yet aren't removed from the cached folder message list. It's a scenario I didn't think of when writing this ``removeMessage`` function :see_no_evil: 

fixes #954

@jancborchardt @DeepDiver1975 test this please :)