### PR TITLE
set accountId and folderId on each message to fix unified inbox replies

### DIFF
--- a/js/mail.js
+++ b/js/mail.js
@@ -1203,9 +1203,9 @@ var Mail = {
 					type: 'reply',
 					onSubmit: Mail.Communication.sendMessage,
 					onDraft: Mail.Communication.saveDraft,
-					accountId: Mail.State.currentAccountId,
-					folderId: Mail.State.currentFolderId,
-					messageId: messageId
+					accountId: message.accountId,
+					folderId: message.folderId,
+					messageId: message.id
 				});
 				replyComposer.render({
 					data: reply

--- a/js/mail.js
+++ b/js/mail.js
@@ -1205,7 +1205,7 @@ var Mail = {
 					onDraft: Mail.Communication.saveDraft,
 					accountId: message.accountId,
 					folderId: message.folderId,
-					messageId: message.id
+					messageId: message.messageId
 				});
 				replyComposer.render({
 					data: reply

--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -270,7 +270,6 @@ views.Composer = Backbone.View.extend({
 		// send the mail
 		var _this = this;
 		var options = {
-			accountId: this.accountId,
 			draftUID: this.draftUID,
 			success: function () {
 				OC.Notification.showTemporary(t('mail', 'Message sent!'));

--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -298,8 +298,15 @@ views.Composer = Backbone.View.extend({
 				}
 			},
 			error: function (jqXHR) {
+				var error = '';
+				if (jqXHR.status === 500) {
+					error = t('mail', 'Server error');
+				} else {
+					var resp = JSON.parse(jqXHR.responseText);
+					error = resp.message;
+				}
 				newMessageSend.prop('disabled', false);
-				OC.Notification.showTemporary(jqXHR.responseJSON.message);
+				OC.Notification.showTemporary(error);
 			},
 			complete: function() {
 				// remove loading feedback
@@ -318,26 +325,8 @@ views.Composer = Backbone.View.extend({
 		};
 
 		if (this.isReply()) {
-			// the account-id is not available when replying from unified inbox
-			// we get the account-id by the account mail address from the message
-			if (this.accountId === -1) {
-				var account = null;
- 
-				var messageViewObject = Mail.State.messageView.collection.get({id: this.messageId});
-				var accountMail = messageViewObject.attributes.accountMail;
-				Mail.State.accounts.some(function (obj) {
-					if (obj.emailAddress === accountMail) {
-						account = obj;
-						return true;
-					}
-				});
-
-				this.accountId    = account.accountId;
-				options.accountId = account.accountId;
-			} else {
-				options.messageId = this.messageId;
-				options.folderId = this.folderId;
-			}
+			options.messageId = this.messageId;
+			options.folderId = this.folderId;
 		}
 
 		this.submitCallback(this.accountId, this.getMessage(), options);

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -153,6 +153,10 @@ class MessagesController extends Controller {
 			}, $json['attachments']);
 		}
 
+		// Add accountId, folderId for unified inbox replies
+		$json['accountId'] = $accountId;
+		$json['folderId'] = $folderId;
+
 		return new JSONResponse($json);
 	}
 

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -18,6 +18,7 @@ use OCA\Mail\Http\HtmlResponse;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\ContactsIntegration;
 use OCA\Mail\Service\IMailBox;
+use OCA\Mail\Service\UnifiedAccount;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -153,9 +154,19 @@ class MessagesController extends Controller {
 			}, $json['attachments']);
 		}
 
-		// Add accountId, folderId for unified inbox replies
+		// Unified inbox hack
+		$messageId = $id;
+		if ($accountId === UnifiedAccount::ID) {
+			// Add accountId, folderId for unified inbox replies
+			list($accountId, $messageId) = json_decode(base64_decode($id));
+			$account = $this->getAccount($accountId);
+			$inbox = $account->getInbox();
+			$folderId = base64_encode($inbox->getFolderId());
+		}
+		$json['messageId'] = $messageId;
 		$json['accountId'] = $accountId;
 		$json['folderId'] = $folderId;
+		// End unified inbox hack
 
 		return new JSONResponse($json);
 	}


### PR DESCRIPTION
Yet another hack to get unified inbox working ;-)

__IMPORTANT:__ clear your local storage with ``localstorage.clear()``. Otherwise you'll run into client side errors when trying to reply to a message that has been cached before. (``accountId`` and ``folderId`` aren't set on old messages).

fixes #949

@jancborchardt @DeepDiver1975 @irgendwie @PoPoutdoor