### PR TITLE
don't show a placeholder if 'from' isn't set on the message

### DIFF
--- a/js/views/message.js
+++ b/js/views/message.js
@@ -30,10 +30,13 @@ views.Message = Backbone.Marionette.ItemView.extend({
 		this.setElement(this.$el);
 
 		var displayName = this.model.get('from');
-		_.each(this.$el.find('.avatar'), function(a) {
-			$(a).height('32px');
-			$(a).imageplaceholder(displayName, displayName);
-		});
+		// Don't show any placeholder if 'from' isn't set
+		if (!displayName) {
+			_.each(this.$el.find('.avatar'), function (a) {
+				$(a).height('32px');
+				$(a).imageplaceholder(displayName, displayName);
+			});
+		}
 	},
 
 	toggleMessageStar: function(event) {


### PR DESCRIPTION
fixes #952 

If anybody has an idea why the message has no 'from' attribute, let me know ;-)

@jancborchardt please test if it's fixed now :-)