### PR TITLE
change attachment template to underscore template

### DIFF
--- a/templates/compose.php
+++ b/templates/compose.php
@@ -7,7 +7,7 @@
 </script>
 
 <script id="mail-attachment-template" type="text/x-handlebars-template">
-	<span>{{displayName}}</span><div class="new-message-attachments-action svg icon-delete"></div>
+	<span><%= displayName %></span><div class="new-message-attachments-action svg icon-delete"></div>
 </script>
 
 <script id="mail-composer" type="text/x-handlebars-template">


### PR DESCRIPTION
For some mysterious reason, the mailto composer seems to use underscore to render the template while in contrast the standard composer uses Handlebars… :confused: 

This isn't necessarily a permanent fix, but I don't know how to resolve this now.

fixes #844