### PR TITLE
Fix message deletion by 'del' hotkey while adding a new mail account.

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -207,8 +207,8 @@ define(function(require) {
 			switch (key) {
 				// If delete key is pressed:
 				case 46:
-					// If not composing a reply:
-					if (!$('.to, .cc, .message-body').is(':focus')) {
+					// If not composing a reply and message list is visible:
+					if (!$('.to, .cc, .message-body').is(':focus') && $('#mail_messages').is(':visible')) {
 						// Mimic a client clicking the delete button for the currently active message.
 						$('.mail_message_summary.active .icon-delete.action.delete').click();
 					}


### PR DESCRIPTION
Fixes #912

It's done by checking if the message list is visible or not. Good idea? Bad idea? Review pls! @ChristophWurst 