### PR TITLE
update version, fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail",
-  "version": "0.0.1",
+  "version": "0.3.0",
   "description": "Mail app for ownCloud",
   "main": "index.js",
   "directories": {
@@ -18,7 +18,7 @@
     "mail"
   ],
   "author": "Thomas Müller and others",
-  "license": "AGPL",
+  "license": "AGPL-3.0",
   "bugs": {
     "url": "https://github.com/owncloud/mail/issues"
   },


### PR DESCRIPTION
fixes warning when executing ``npm install``.

Previously it said:
``npm WARN package.json mail@0.0.1 license should be a valid SPDX license expression``

@Gomez @jancborchardt @itheiss 