### PR TITLE
Add tests to the list of allowed paths

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ define('PHPUNIT_RUN', 1);
 require_once __DIR__.'/../../../lib/base.php';
 require_once __DIR__.'/../vendor/autoload.php';
 
-if (version_compare(implode('.', \OCP\Util::getVersion()), '8.2', '<=')) {
+if (version_compare(implode('.', \OCP\Util::getVersion()), '8.1', '<=')) {
 	\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ define('PHPUNIT_RUN', 1);
 require_once __DIR__.'/../../../lib/base.php';
 require_once __DIR__.'/../vendor/autoload.php';
 
-if (version_compare(implode('.', \OCP\Util::getVersion()), '8.1', '<=')) {
+if (version_compare(implode('.', \OCP\Util::getVersion()), '8.2', '>=')) {
 	\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,10 @@ define('PHPUNIT_RUN', 1);
 
 require_once __DIR__.'/../../../lib/base.php';
 require_once __DIR__.'/../vendor/autoload.php';
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+
+if (version_compare(implode('.', \OCP\Util::getVersion()), '8.2', '<=')) {
+	\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+}
 
 if(!class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,7 @@ define('PHPUNIT_RUN', 1);
 
 require_once __DIR__.'/../../../lib/base.php';
 require_once __DIR__.'/../vendor/autoload.php';
+\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 
 if(!class_exists('PHPUnit_Framework_TestCase')) {
 	require_once('PHPUnit/Autoload.php');


### PR DESCRIPTION
Most apps can't run their tests any more because of a new restriction in core:
https://github.com/owncloud/core/pull/18396

This fixes the bootstrap.

@DeepDiver1975 @jancborchardt 