### PR TITLE
use own jquery for unit tests because oc7/oc8 path differs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "backbone.marionette": "~2.4.2",
     "domready": "~1.0.8",
     "handlebars": "~3.0.3",
+    "jquery": "~2.1.4",
     "jQuery-Storage-API": "julien-maurel/jQuery-Storage-API#~1.7.4",
     "jquery-visibility": "~1.0.11",
     "requirejs": "~2.1.20",

--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -20,6 +20,7 @@ require.config({
 		domready: 'vendor/domready/ready.min',
 		handlebars: 'vendor/handlebars/handlebars',
 		marionette: 'vendor/backbone.marionette/lib/backbone.marionette',
+		underscore: 'vendor/underscore/underscore',
 		OC: 'tests/mocks/OC',
 		text: 'vendor/text/text'
 	},

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,15 +9,16 @@ module.exports = function(config) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'../../core/vendor/underscore/underscore.js',
-			'../../core/vendor/jquery/jquery.min.js',
+			'js/vendor/jquery/dist/jquery.js',
 			{pattern: 'js/*/*.js', included: false},
 			{pattern: 'js/*.js', included: false},
 			{pattern: 'js/templates/*.html', included: false},
 			{pattern: 'js/vendor/backbone/backbone.js', included: false},
-			{pattern: 'js/vendor/handlebars/handlebars.js', included: false},
 			{pattern: 'js/vendor/backbone.marionette/lib/backbone.marionette.js', included: false},
+			{pattern: 'js/vendor/jquery/dist/jquery.js', included: false},
+			{pattern: 'js/vendor/handlebars/handlebars.js', included: false},
 			{pattern: 'js/vendor/text/text.js', included: false},
+			{pattern: 'js/vendor/underscore/underscore.js', included: false},
 			{pattern: 'js/tests/mocks/*.js', included: false},
 			{pattern: 'js/tests/*.js', included: false},
 			'js/tests/test-main.js'


### PR DESCRIPTION
I found out oc7 and oc8 have different js vendor paths, therefore jQuery could not be loaded properly in oc7 karma tests.
Switching to an own jQuery version (``js/vendor/jquery/dist/jquery.js``) fixes the problem for now.

If I didn't miss anything, we should have green travis status again :speak_no_evil: 

@Gomez @irgendwie @jancborchardt 