### PR TITLE
load app in bootstrap.php to fix php unit tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 if (version_compare(implode('.', \OCP\Util::getVersion()), '8.2', '>=')) {
 	\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
+	\OC_App::loadApp('mail');
 }
 
 if(!class_exists('PHPUnit_Framework_TestCase')) {


### PR DESCRIPTION
this is needed in addition to #1023 because of new path restrictions of core (https://github.com/owncloud/core/pull/18839)

@Gomez @irgendwie @Xenopathic @nickvergessen @oparoz 