### PR TITLE
Only install production js deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,12 @@ all: dist
 
 clean:
 	rm -rf $(build_dir)
+	rm -rf node_modules
 
 dist: install-npm-deps install-bower-deps optimize-js
 
 install-npm-deps: package.json
-	npm install
+	npm install --production
 
 install-bower-deps: bower.json install-npm-deps
 	./node_modules/bower/bin/bower install

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/owncloud/mail",
   "devDependencies": {
-    "bower": "^1.5.2",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-jscs": "^1.8.0",
@@ -42,5 +41,7 @@
     "phantomjs": "^1.9.18"
   },
   "dependencies": {
+    "bower": "^1.5.2",
+    "requirejs": "^2.1.20"
   }
 }


### PR DESCRIPTION
The Makefile installs now only js deps for production use (bower for frontside & requirejs for the optimization).
A makefile option for dev deps can now be done too.