### PR TITLE
Fix message deletion hotkey if searchbar is focused.

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -213,8 +213,12 @@ define(function(require) {
 			switch (key) {
 				// If delete key is pressed:
 				case 46:
-					// If not composing a reply:
-					if (!$('.to, .cc, .message-body').is(':focus')) {
+					// If not composing a reply
+					// and message list is visible (not being in a settings dialog)
+					// and if searchbox is not focused
+					if (!$('.to, .cc, .message-body').is(':focus') &&
+							$('#mail_messages').is(':visible') &&
+							!$('#searchbox').is(':focus')) {
 						// Mimic a client clicking the delete button for the currently active message.
 						$('.mail_message_summary.active .icon-delete.action.delete').click();
 					}


### PR DESCRIPTION
If you are in the searchbar and hit the 'del'-key, the current focused message gets deleted. With this commit if the searchbar is focused, messages won't get deleted.

**Also** re-adds the exception for the 'add mail account' dialog (#969), which accidentally got deleted in this commit:

https://github.com/owncloud/mail/commit/d7315a8522d574cdb728fcc18ae6453504b901ce#diff-e3f4efbe9f975868bcbac1c372abecf8L210