### PR TITLE
increase timeout to prevent failing checks when travis takes too long

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,9 +1,6 @@
 filter:
     excluded_paths:
         - 'vendor/*'
-        - 'js/jquery*'
-        - 'js/handlebars*'
-        - 'js/backbone*'
         - 'l10n/*'
 
 imports:
@@ -12,4 +9,4 @@ imports:
 
 tools:
     external_code_coverage:
-        timeout: 3600 # Timeout in seconds. 60 minutes
+        timeout: 7200 # Timeout in seconds. 120 minutes


### PR DESCRIPTION
@DeepDiver1975 @Gomez @irgendwie good idea? Today travis is again extremely slow, therefore all scrutinizer checks fail :/