### PR TITLE
enable dependency caching for travis to speed up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ branches:
     - master
     - /^stable\d+(\.\d+)?$/
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - $HOME/.npm
+    - $HOME/.cache/bower
+
 before_install:
   - composer self-update
   - composer install


### PR DESCRIPTION
* [x] cache composer packages
* [x] cache npm packages
* [x] cache bower packages

Directory | Size
---|---
node_modules | 163MB
js/vendor | 3.2MB
vendor | 12 MB

## Comparison of time needed to install dependencies

 | without cache | with cache
---|---|---
composer | 17.85s | 3.29s
npm | 67.09s | 40.50s
bower | 6.22s | 2.84s

I made this comparison by clearing the cache and running the test twice.

Result: we can save about 45s per build, that's 7.5min for running all 10 tests :rocket: 

@DeepDiver1975 @Gomez @Xenopathic @clementhk @zinks- review please