### PR TITLE
use Makefile to set up dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,19 @@ install-deps: install-composer-deps install-npm-deps install-bower-deps
 install-composer-deps: composer.phar
 	php composer.phar install
 
-install-npm-deps: package.json
+install-npm-deps:
 	npm install --production
+
+install-npm-deps-dev:
+	npm install --deps
 
 install-bower-deps: bower.json install-npm-deps
 	./node_modules/bower/bin/bower install
 
 optimize-js: install-deps
 	./node_modules/requirejs/bin/r.js -o build.js
+
+dev-setup: install-composer-deps install-npm-deps-dev install-bower-deps
 
 update-composer:
 	rm -f composer.lock


### PR DESCRIPTION
@Gomez @enoch85 I think this is now what we agreed on: the Makefile can be used to install the dev environment via `make dev-setup`.

`make` or `make appstore` creates the package, just like it was before.

Feel free to take over this PR and adjust the info in the readme ;-)

@irgendwie @jancborchardt

This replaces #1063
