### PR TITLE
fix transparency of tooltip in mail header

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -550,6 +550,13 @@ input.submit-message {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	opacity: .5;
 }
+#mail-message-header .transparency {
+	color: rgba(0, 0, 0, .3) !important;
+	opacity: 1;
+}
+#mail-message-header .transparency a {
+	color: rgba(0, 0, 0, .5) !important;
+}
 
 #mail-message {
 	position: absolute;


### PR DESCRIPTION
The tooltips for the names in the mail header are now normal, not transparent anymore. Please review @irgendwie and everyone. :)