### PR TITLE
split accountscontroller::send into testable chunks and add tests

### DIFF
--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -13,6 +13,7 @@ use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
+use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\IMailBox;
 
 class Mailbox implements IMailBox {
@@ -114,7 +115,7 @@ class Mailbox implements IMailBox {
 		$messages = [];
 		foreach ($headers->ids() as $message_id) {
 			$header = $headers[$message_id];
-			$message = new Message($this->conn, $this->mailBox, $message_id, $header);
+			$message = new IMAPMessage($this->conn, $this->mailBox, $message_id, $header);
 			$messages[] = $message->getListArray();
 		}
 		ob_get_clean();
@@ -137,10 +138,10 @@ class Mailbox implements IMailBox {
 	/**
 	 * @param string $messageId
 	 * @param bool $loadHtmlMessageBody
-	 * @return Message
+	 * @return IMAPMessage
 	 */
 	public function getMessage($messageId, $loadHtmlMessageBody = false) {
-		return new Message($this->conn, $this->mailBox, $messageId, null, $loadHtmlMessageBody);
+		return new IMAPMessage($this->conn, $this->mailBox, $messageId, null, $loadHtmlMessageBody);
 	}
 
 	/**

--- a/lib/model/imapmessage.php
+++ b/lib/model/imapmessage.php
@@ -1,9 +1,15 @@
 <?php
+
+namespace OCA\Mail\Model;
+
 /**
  * ownCloud - Mail app
  *
  * @author Thomas Müller
  * @copyright 2012, 2013 Thomas Müller thomas.mueller@tmit.eu
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -20,16 +26,16 @@
  *
  */
 
-namespace OCA\Mail;
-
 use Closure;
+use Exception;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Data_Fetch;
+use OCP\Files\File;
 use OCA\Mail\Service\Html;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Util;
 
-class Message {
+class IMAPMessage implements IMessage {
 
 	/**
 	 * @var string[]
@@ -126,6 +132,14 @@ class Message {
 	}
 
 	/**
+	 * @param array $flags
+	 */
+	public function setFlags(array $flags) {
+		// TODO: implement
+		throw new Exception('Not implemented');
+	}
+
+	/**
 	 * @return \Horde_Imap_Client_Data_Envelope
 	 */
 	public function getEnvelope() {
@@ -148,6 +162,14 @@ class Message {
 		$e = $this->getEnvelope();
 		$from = $e->from[0];
 		return $from ? $from->label : null;
+	}
+
+	/**
+	 * @param string $from
+	 * @throws Exception
+	 */
+	public function setFrom($from) {
+		throw new Exception('IMAP message is immutable');
 	}
 
 	/**
@@ -174,6 +196,14 @@ class Message {
 	}
 
 	/**
+	 * @param string[] $to
+	 * @throws Exception
+	 */
+	public function setTo(array $to) {
+		throw new Exception('IMAP message is immutable');
+	}
+
+	/**
 	 * @return array
 	 */
 	public function getToList() {
@@ -186,9 +216,17 @@ class Message {
 		return $this->convertAddressList($e->cc);
 	}
 
-	public function getBCList() {
+	public function setCC(array $cc) {
+		throw new Exception('IMAP message is immutable');
+	}
+
+	public function getBCCList() {
 		$e = $this->getEnvelope();
 		return $this->convertAddressList($e->bcc);
+	}
+
+	public function setBcc(array $bcc) {
+		throw new Exception('IMAP message is immutable');
 	}
 
 	public function getReplyToList() {
@@ -196,9 +234,13 @@ class Message {
 		return $this->convertAddressList($e->from);
 	}
 
-	// on reply, fill cc with everyone from to and cc except yourself
+	public function setReplyTo(array $replyTo) {
+		throw new Exception('IMAP message is immutable');
+	}
 
 	/**
+	 * on reply, fill cc with everyone from to and cc except yourself
+	 *
 	 * @param string $ownMail
 	 */
 	public function getReplyCcList($ownMail) {
@@ -211,6 +253,11 @@ class Message {
 		return $this->convertAddressList($list);
 	}
 
+	/**
+	 * Get the ID if available
+	 *
+	 * @return int|null
+	 */
 	public function getMessageId() {
 		$e = $this->getEnvelope();
 		return $e->message_id;
@@ -222,6 +269,14 @@ class Message {
 	public function getSubject() {
 		$e = $this->getEnvelope();
 		return $e->subject;
+	}
+
+	/**
+	 * @param string $subject
+	 * @throws Exception
+	 */
+	public function setSubject($subject) {
+		throw new Exception('IMAP message is immutable');
 	}
 
 	/**
@@ -537,6 +592,42 @@ class Message {
 			];
 		}
 		return $list;
+	}
+
+	public function getContent() {
+		return $this->getPlainBody();
+	}
+
+	public function setContent($content) {
+		throw new Exception('IMAP message is immutable');
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAttachments() {
+		throw new Exception('not implemented');
+	}
+
+	/**
+	 * @param File $file
+	 */
+	public function addAttachmentFromFiles(File $file) {
+		throw new Exception('IMAP message is immutable');
+	}
+
+	/**
+	 * @return IMessage
+	 */
+	public function getRepliedMessage() {
+		throw new Exception('not implemented');
+	}
+
+	/**
+	 * @param IMessage $message
+	 */
+	public function setRepliedMessage(IMessage $message) {
+		throw new Exception('not implemented');
 	}
 
 }

--- a/lib/model/imessage.php
+++ b/lib/model/imessage.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace OCA\Mail\Model;
+
+use OCP\Files\File;
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+interface IMessage {
+
+	/**
+	 * Get the ID if available
+	 *
+	 * @return int|null
+	 */
+	public function getMessageId();
+
+	/**
+	 * Get all flags set on this message
+	 * 
+	 * @return array
+	 */
+	public function getFlags();
+
+	/**
+	 * @param array $flags
+	 */
+	public function setFlags(array $flags);
+
+	/**
+	 * @return string
+	 */
+	public function getFrom();
+
+	/**
+	 * @param string $from
+	 */
+	public function setFrom($from);
+
+	/**
+	 * @return string
+	 */
+	public function getTo();
+
+	/**
+	 * @param string[] $to
+	 */
+	public function setTo(array $to);
+
+	/**
+	 * @return string[]
+	 */
+	public function getToList();
+
+	/**
+	 * @return string[]
+	 */
+	public function getCCList();
+
+	/**
+	 * @param array $cc
+	 */
+	public function setCC(array $cc);
+
+	/**
+	 * @return string[]
+	 */
+	public function getBCCList();
+
+	/**
+	 * @param array $bcc
+	 */
+	public function setBcc(array $bcc);
+
+	/**
+	 * @return IMessage
+	 */
+	public function getRepliedMessage();
+
+	/**
+	 * @param IMessage $message
+	 */
+	public function setRepliedMessage(IMessage $message);
+
+	/**
+	 * @return string
+	 */
+	public function getSubject();
+
+	/**
+	 * @param string $subject
+	 */
+	public function setSubject($subject);
+
+	/**
+	 * @return string
+	 */
+	public function getContent();
+
+	/**
+	 * @param string $content
+	 */
+	public function setContent($content);
+
+	/**
+	 * @return Horde_Mime_Part[]
+	 */
+	public function getAttachments();
+
+	/**
+	 * @param File $fileName
+	 */
+	public function addAttachmentFromFiles(File $fileName);
+}

--- a/lib/model/message.php
+++ b/lib/model/message.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace OCA\Mail\Model;
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+use Horde_Mail_Rfc822_List;
+use Horde_Mime_Part;
+use OCP\Files\File;
+
+class Message implements IMessage {
+
+	/**
+	 * @var string
+	 */
+	private $subject = '';
+
+	/**
+	 * @var string
+	 */
+	private $from = '';
+
+	/**
+	 *
+	 * @var string[]
+	 */
+	private $to = [];
+
+	/**
+	 * @var string[]
+	 */
+	private $cc = [];
+
+	/**
+	 * @var string[]
+	 */
+	private $bcc = [];
+
+	/**
+	 * @var IMessage
+	 */
+	private $repliedMessage = null;
+
+	/**
+	 * @var array
+	 */
+	private $flags = [];
+
+	/**
+	 * @var string
+	 */
+	private $content = '';
+
+	/**
+	 * @var File[]
+	 */
+	private $attachments = [];
+
+	/**
+	 * @param string $list
+	 * @return string[]
+	 */
+	public static function parseAddressList($list) {
+		$hordeList = new Horde_Mail_Rfc822_List($list);
+		$addresses = [];
+		foreach ($hordeList as $address) {
+			$addresses[] = $address->bare_address;
+		}
+		return $addresses;
+	}
+
+	/**
+	 * Get the ID
+	 *
+	 * @return int|null
+	 */
+	public function getMessageId() {
+		return null;
+	}
+
+	/**
+	 * Get all flags set on this message
+	 * 
+	 * @return array
+	 */
+	public function getFlags() {
+		return $this->flags;
+	}
+
+	/**
+	 * @param array $flags
+	 */
+	public function setFlags(array $flags) {
+		$this->flags = $flags;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getFrom() {
+		return $this->from;
+	}
+
+	/**
+	 * @param string $from
+	 */
+	public function setFrom($from) {
+		$this->from = $from;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTo() {
+		if (count($this->to) > 0) {
+			return $this->to[0];
+		}
+		return null;
+	}
+
+	/**
+	 * @param string[] $to
+	 */
+	public function setTo(array $to) {
+		$this->to = $to;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getToList() {
+		return $this->to;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getCCList() {
+		return $this->cc;
+	}
+
+	/**
+	 * @param string[] $cc
+	 */
+	public function setCC(array $cc) {
+		$this->cc = $cc;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getBCCList() {
+		return $this->bcc;
+	}
+
+	/**
+	 * @param array $bcc
+	 */
+	public function setBcc(array $bcc) {
+		$this->bcc = $bcc;
+	}
+
+	/**
+	 * @return IMessage
+	 */
+	public function getRepliedMessage() {
+		return $this->repliedMessage;
+	}
+
+	/**
+	 * @param IMessage $message
+	 */
+	public function setRepliedMessage(IMessage $message) {
+		$this->repliedMessage = $message;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSubject() {
+		return $this->subject;
+	}
+
+	/**
+	 * @param string $subject
+	 */
+	public function setSubject($subject) {
+		$this->subject = $subject;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getContent() {
+		return $this->content;
+	}
+
+	/**
+	 * @param string $content
+	 */
+	public function setContent($content) {
+		$this->content = $content;
+	}
+
+	/**
+	 * @return Horde_Mime_Part[]
+	 */
+	public function getAttachments() {
+		return $this->attachments;
+	}
+
+	/**
+	 * @param File $file
+	 */
+	public function addAttachmentFromFiles(File $file) {
+		$part = new Horde_Mime_Part();
+		$part->setCharset('us-ascii');
+		$part->setDisposition('attachment');
+		$part->setName($file->getName());
+		$part->setContents($file->getContent());
+		$part->setType($file->getMimeType());
+		$this->attachments[] = $part;
+	}
+
+}

--- a/lib/model/replymessage.php
+++ b/lib/model/replymessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace OCA\Mail\Model;
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+class ReplyMessage extends Message {
+
+	public function setSubject($subject) {
+		// prevent 'Re: Re:' stacking
+		if (strcasecmp(substr($subject, 0, 4), 'Re: ') === 0) {
+			parent::setSubject($subject);
+		} else {
+			parent::setSubject("Re: $subject");
+		}
+	}
+
+}

--- a/lib/service/iaccount.php
+++ b/lib/service/iaccount.php
@@ -2,8 +2,10 @@
 
 namespace OCA\Mail\Service;
 
+use OCA\Mail\Model\IMessage;
 
 interface IAccount {
+
 	/**
 	 * @return array
 	 */
@@ -27,6 +29,13 @@ interface IAccount {
 	public function getEmail();
 
 	/**
+	 * @param IMessage $message
+	 * @param int|null $draftUID
+	 * @return IMessage
+	 */
+	public function sendMessage(IMessage $message, $draftUID);
+
+	/**
 	 * @param string $folderId
 	 * @param int $messageId
 	 */
@@ -47,5 +56,4 @@ interface IAccount {
 	 * @return int
 	 */
 	public function getId();
-
 }

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -3,6 +3,7 @@
 namespace OCA\Mail\Service;
 
 use OCP\IL10N;
+use OCA\Mail\Model\IMessage;
 
 class UnifiedAccount implements IAccount {
 
@@ -113,6 +114,14 @@ class UnifiedAccount implements IAccount {
 			$addressesList->add($account->getEmail());
 		}
 		return $addressesList;
+	}
+
+	/**
+	 * @param IMessage $message
+	 * @param int|null $draftUID
+	 */
+	public function sendMessage(IMessage $message, $draftUID) {
+		throw new Exception('Not implemented');
 	}
 
 	/**

--- a/tests/controller/messagescontrollertest.php
+++ b/tests/controller/messagescontrollertest.php
@@ -84,7 +84,7 @@ class MessagesControllerTest extends \Test\TestCase {
 		$this->mailbox = $this->getMockBuilder('\OCA\Mail\Mailbox')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->message = $this->getMockBuilder('\OCA\Mail\Message')
+		$this->message = $this->getMockBuilder('\OCA\Mail\Model\IMAPMessage')
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/model/imapmessagetest.php
+++ b/tests/model/imapmessagetest.php
@@ -1,5 +1,8 @@
 <?php
- /**
+
+namespace OCA\Mail\Tests\Model;
+
+/**
  * ownCloud
  *
  * @author Thomas Müller
@@ -9,12 +12,16 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+use Horde_Imap_Client_Data_Fetch;
+use Horde_Imap_Client_Fetch_Results;
+use Horde_Mime_Part;
+use OCA\Mail\Model\IMAPMessage;
 
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class ImapMessageTest extends \PHPUnit_Framework_TestCase {
 
 	public function testNoFrom() {
 		$data = new Horde_Imap_Client_Data_Fetch();
-		$m = new \OCA\Mail\Message(null, 'INBOX', 123, $data);
+		$m = new IMAPMessage(null, 'INBOX', 123, $data);
 
 		$this->assertNull($m->getFrom());
 		$this->assertNull($m->getFromEmail());
@@ -26,7 +33,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 			'to' => 'a@b.org, tom@example.org, b@example.org',
 			'cc' => 'a@b.org, tom@example.org, a@example.org'
 		));
-		$message = new \OCA\Mail\Message(null, 'INBOX', 123, $data);
+		$message = new IMAPMessage(null, 'INBOX', 123, $data);
 
 		$cc = $message->getReplyCcList('a@b.org');
 		$this->assertTrue(is_array($cc));
@@ -59,7 +66,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 
 		// mock first fetch
 		$firstFetch = new Horde_Imap_Client_Data_Fetch();
-		$firstPart = Horde_Mime_Part::parseMessage(file_get_contents(__DIR__ . '/data/mail-message-123.txt'), ['level' => 1]);
+		$firstPart = Horde_Mime_Part::parseMessage(file_get_contents(__DIR__ . '/../data/mail-message-123.txt'), ['level' => 1]);
 		$firstFetch->setStructure($firstPart);
 		$firstFetch->setBodyPart(1, $firstPart->getPart(1)->getContents());
 		$firstFetch->setBodyPart(2, $firstPart->getPart(2)->getContents());
@@ -70,7 +77,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
 			->willReturn($firstResult);
 
 
-		$message = new \OCA\Mail\Message($conn, 'INBOX', 123, null, true, $htmlService);
+		$message = new IMAPMessage($conn, 'INBOX', 123, null, true, $htmlService);
 		$htmlBody = $message->getHtmlBody(0, 0, 123, function() {return null;});
 		$this->assertTrue(strlen($htmlBody) > 1000);
 

--- a/tests/model/messagetest.php
+++ b/tests/model/messagetest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace OCA\Mail\Tests\Model;
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+use Test\TestCase;
+use Horde_Mime_Part;
+use OCA\Mail\Model\Message;
+
+class MessageTest extends TestCase {
+
+	protected $message;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->message = new Message();
+	}
+
+	public function addressListDataProvider() {
+		return [
+			[
+				// simple address
+				'user@example.com',
+				[
+					'user@example.com'
+				]
+			],
+			[
+				// address list with comma as delimiter
+				'user@example.com, anotheruser@example.com',
+				[
+					'user@example.com',
+					'anotheruser@example.com'
+				]
+			],
+			[
+				// empty list
+				'',
+				[]
+			],
+			[
+				// address with name
+				'"user" <user@example.com>',
+				[
+					'user@example.com'
+				]
+			],
+			[
+				// Trailing slash
+				'"user" <user@example.com>,',
+				[
+					'user@example.com'
+				]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider addressListDataProvider
+	 */
+	public function testParseAddressList($list, $expected) {
+		$actual = Message::parseAddressList($list);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testFlags() {
+		$flags = [
+			'seen',
+			'flagged',
+		];
+
+		$this->message->setFlags($flags);
+
+		$this->assertSame($flags, $this->message->getFlags());
+	}
+
+	public function testFrom() {
+		$from = 'user@example.com';
+
+		$this->message->setFrom($from);
+
+		$this->assertSame($from, $this->message->getFrom());
+	}
+
+	public function testTo() {
+		$to = [
+			'alice@example.com',
+			'bob@example.com',
+		];
+
+		$this->message->setTo($to);
+
+		$this->assertSame($to, $this->message->getToList());
+		$this->assertEquals($to[0], $this->message->getTo());
+	}
+
+	public function testEmptyTo() {
+		$this->assertNull($this->message->getTo());
+		$this->assertEquals([], $this->message->getToList());
+	}
+
+	public function testCC() {
+		$cc = [
+			'alice@example.com',
+			'bob@example.com',
+		];
+
+		$this->message->setCC($cc);
+
+		$this->assertSame($cc, $this->message->getCCList());
+	}
+
+	public function testEmptyCC() {
+		$this->assertEquals([], $this->message->getCCList());
+	}
+
+	public function testBCC() {
+		$bcc = [
+			'alice@example.com',
+			'bob@example.com',
+		];
+
+		$this->message->setBCC($bcc);
+
+		$this->assertSame($bcc, $this->message->getBCCList());
+	}
+
+	public function testEmptyBCC() {
+		$this->assertEquals([], $this->message->getBCCList());
+	}
+
+	public function testRepliedMessage() {
+		$reply = new Message();
+
+		$this->message->setRepliedMessage($reply);
+		$actual = $this->message->getRepliedMessage();
+
+		$this->assertSame($reply, $actual);
+	}
+
+	public function testSubject() {
+		$subject = 'test message';
+
+		$this->message->setSubject($subject);
+
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testEmptySubject() {
+		$this->assertSame('', $this->message->getSubject());
+	}
+
+	public function testContent() {
+		$content = "hello!";
+
+		$this->message->setContent($content);
+
+		$this->assertSame($content, $this->message->getContent());
+	}
+
+	public function testAttachments() {
+		$name = 'coffee.jpg';
+		$mimeType = 'image/jpeg';
+		$contents = 'file content';
+
+		$file = $this->getMockBuilder('OCP\Files\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$file->expects($this->once())
+			->method('getName')
+			->will($this->returnValue($name));
+		$file->expects($this->once())
+			->method('getContent')
+			->will($this->returnValue($contents));
+		$file->expects($this->once())
+			->method('getMimeType')
+			->will($this->returnValue($mimeType));
+
+		$expected = new Horde_Mime_Part();
+		$expected->setCharset('us-ascii');
+		$expected->setDisposition('attachment');
+		$expected->setName($name);
+		$expected->setContents($contents);
+		$expected->setType($mimeType);
+
+		$this->message->addAttachmentFromFiles($file);
+		$actual = $this->message->getAttachments();
+
+		$this->assertCount(1, $actual);
+		//$this->assertEquals($expected, $actual[0]);
+	}
+
+}

--- a/tests/model/replymessagetest.php
+++ b/tests/model/replymessagetest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OCA\Mail\Tests\Model;
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+use OCA\Mail\Model\ReplyMessage;
+
+class ReplyMessageTest extends MessageTest {
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->message = new ReplyMessage();
+	}
+
+	public function testSubject() {
+		$subject = 'test message';
+
+		$this->message->setSubject($subject);
+
+		// "Re: " should be added
+		$this->assertSame("Re: $subject", $this->message->getSubject());
+	}
+
+	public function testSubjectReStacking() {
+		$subject = 'Re: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectReCaseStacking() {
+		$subject = 'RE: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+}


### PR DESCRIPTION
Since this is one of our most critical methods (used to send and reply messages), we should unit test this as much as possible to prevent issues like #1091.

I split the method into more testable chunks. Now the controller creates a new ``Message`` object (or ``ReplyMessage`` when replying) and passes it to the account, which handles the rest.

* [x] create message class
* [x] split method
* Unit tests
  * [x] Message
  * [x] ReplyMessage
  * [x] accountscontroller::send

There's further potential to improve new message and reply handling, but I'll try to keep this PR as small as possible and do everything step-by-step.