### PR TITLE
construct application to increase code coverage

### DIFF
--- a/tests/applicationtest.php
+++ b/tests/applicationtest.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+use Test\TestCase;
+use OCA\Mail\AppInfo\Application;
+
+class ApplicationTest extends TestCase {
+
+	public function testConstrucor() {
+		// Not really a test – it's just about code coverage
+		$app = new Application();
+	}
+
+}


### PR DESCRIPTION
It's more or less useless, but at least code coverage should be pushed if the application is constructed when testing :D

https://scrutinizer-ci.com/g/owncloud/mail/code-structure/master?elementType=class&orderField=test_coverage&order=asc&changesExpanded=0