### PR TITLE
exclude tests vom scrutinizer checks

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,6 +5,7 @@ filter:
         - 'js/handlebars*'
         - 'js/backbone*'
         - 'l10n/*'
+        - 'tests'
 
 imports:
     - javascript


### PR DESCRIPTION
Since code coverage numbers generated by scrutinizer don't make any sense to me, maybe tests file shouldn't be analysed at all.