### PR TITLE
Fixed UTF7 encoding instead of UTF8 for mailbox-draftfolders

### DIFF
--- a/lib/account.php
+++ b/lib/account.php
@@ -482,7 +482,7 @@ class Account implements IAccount {
 	public function deleteDraft($messageId) {
 		$draftsFolder = $this->getDraftsFolder();
 		
-		$draftsMailBox = new \Horde_Imap_Client_Mailbox($draftsFolder->getFolderId(), true);
+		$draftsMailBox = new \Horde_Imap_Client_Mailbox($draftsFolder->getFolderId(), false);
 		$this->getImapConnection()->expunge($draftsMailBox);
 	}
 


### PR DESCRIPTION
The constructor of "Horde_Imap_Client_Mailbox" requires a "false" for UTF-8 encoding. In the current code-base a "true" was set so that the horde-backend uses UTF-7 which caused problems with translated draft-folders (like "Entwürfe" which where mistransformed to "Entw??rfe").