### PR TITLE
Ignore mail.min.js in jscs jshint check

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
 			options: {
 				jshintrc: '.jshintrc'
 			},
-			all: ['Gruntfile.js', 'js/*.js', 'js/models/*.js', 'js/views/*.js']
+			all: ['Gruntfile.js', 'js/*.js', 'js/models/*.js', 'js/views/*.js', '!js/mail.min.js']
 		},
 		jscs: {
 			src: '<%= jshint.all %>',


### PR DESCRIPTION
Lets ignore the mail.min.js, confuse if you run grunt locally
@ChristophWurst Easy merge. No effect if its missing