### PR TITLE
fix search by adding a proxy

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -12,9 +12,6 @@ define(function(require) {
 	'use strict';
 
 	var timeoutID = null;
-	function attach(search) {
-		search.setFilter('mail', require('app').Search.filter);
-	}
 
 	function filter(query) {
 		window.clearTimeout(timeoutID);
@@ -25,7 +22,6 @@ define(function(require) {
 	}
 
 	return {
-		attach: attach,
 		filter: filter
 	};
 });

--- a/js/searchproxy.js
+++ b/js/searchproxy.js
@@ -1,0 +1,36 @@
+/* global OC, _ */
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2015
+ */
+
+var SearchProxy = {};
+
+(function(OC, _) {
+	'use strict';
+
+	var filter = function() {};
+
+	SearchProxy = {
+		attach: function(search) {
+			search.setFilter('mail', this.filterProxy);
+		},
+		filterProxy: function(query) {
+			filter(query);
+		},
+		setFilter: function(newFilter) {
+			filter = newFilter;
+		}
+	};
+
+	if (!_.isUndefined(OC.Plugins)) {
+		OC.Plugins.register('OCA.Search', SearchProxy);
+	}
+
+})(OC, _);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,4 @@
-/* global Notification, adjustControlsWidth */
+/* global Notification, adjustControlsWidth, SearchProxy */
 
 /**
  * ownCloud - Mail
@@ -108,9 +108,8 @@ define(function(require) {
 			Notification.requestPermission();
 		}
 
-		if (!_.isUndefined(OC.Plugins)) {
-			OC.Plugins.register('OCA.Search', require('app').Search);
-		}
+		// Register actual filter method
+		SearchProxy.setFilter(require('app').Search.filter);
 
 		function split(val) {
 			return val.split(/,\s*/);

--- a/templates/index.php
+++ b/templates/index.php
@@ -11,6 +11,7 @@ script('mail','vendor/autosize/jquery.autosize');
 script('mail', 'vendor/jQuery-Storage-API/jquery.storageapi');
 script('mail', 'vendor/jquery-visibility/jquery-visibility');
 script('mail', 'vendor/requirejs/require');
+script('mail','searchproxy');
 if ($debug) {
 	// Load JS dependencies asynchronously as specified in require_config.js
 	script('mail', 'require_config');


### PR DESCRIPTION
I added a search proxy that is registered as app search on page load. The actual search module is then registered to that proxy shortly afterwards when it has been loaded asynchronously.

The only disadvantage of that approach is that the search field actually doesn't work for the time it needs to load the search module. However, that's actually a very short time on a production system since JavaScript source files are combined and compressed. Hence, search is not working for less than a second.

@jancborchardt @irgendwie @Gomez review please

fixes #1057