### PR TITLE
fix unified inbox replying

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -60,7 +60,7 @@ class MessagesController extends Controller {
 	/**
 	 * @var IAccount[]
 	 */
-	private $accounts;
+	private $accounts = [];
 
 	/**
 	 * @param string $appName


### PR DESCRIPTION
As described in issue #1128, the unified inbox hack I introduced in PR #956 was not implemented for bulk message loads. Now we have a unified-unified-inbox hack :see_no_evil:

@owncloud/mail give it a test please. I'm not sure if that works in all scenarios.
@Gomez thanks for the hint of the missing accountId

fixes #1128