### PR TITLE
fix mailto composer

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -47,6 +47,7 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('MailAccountMapper'),
+				$c->query('ServerContainer')->getURLGenerator(),
 				$c->query('UserId')
 			);
 		});

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -12,6 +12,58 @@ define(function(require) {
 	'use strict';
 
 	var $ = require('jquery');
+	var _ = require('underscore');
+
+	function urldecode(str) {
+		return decodeURIComponent((str + '').replace(/\+/g, '%20'));
+	}
+
+	/**
+	 * Handle mailto links
+	 *
+	 * @returns {undefined}
+	 */
+	function handleMailTo() {
+		var hash = window.location.hash;
+		if (hash === '' || hash === '#') {
+			// Nothing to do
+			return;
+		}
+
+		// Remove leading #
+		hash = hash.substr(1);
+
+		var composerOptions = {};
+		var params = hash.split('&');
+
+		_.each(params, function(param) {
+			param = param.split('=');
+			var key = param[0];
+			var value = urldecode(param[1]);
+
+			switch (key) {
+				case 'mailto':
+				case 'to':
+					composerOptions.to = value;
+					break;
+				case 'cc':
+					composerOptions.cc = value;
+					break;
+				case 'bcc':
+					composerOptions.bcc = value;
+					break;
+				case 'subject':
+					composerOptions.subject = value;
+					break;
+				case 'body':
+					composerOptions.body = value;
+					break;
+			}
+		});
+
+		window.location.hash = '';
+		require('app').UI.openComposer(composerOptions);
+	}
 
 	function loadFolder(accountId, activeId) {
 		var fetchingFolders = require('app').request('folder:entities', accountId);
@@ -37,7 +89,7 @@ define(function(require) {
 				require('app').trigger('folder:load', accountId, folderId, false);
 
 				// Open composer if 'mailto' url-param is set
-				// TODO: implement
+				handleMailTo();
 
 				// Save current folder
 				UI.setFolderActive(accountId, folderId);

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -36,6 +36,9 @@ define(function(require) {
 
 				require('app').trigger('folder:load', accountId, folderId, false);
 
+				// Open composer if 'mailto' url-param is set
+				// TODO: implement
+
 				// Save current folder
 				UI.setFolderActive(accountId, folderId);
 				require('app').State.currentAccountId = accountId;


### PR DESCRIPTION
This brings back mailto link support. Works with recipient, cc, bcc, subject and body.

@owncloud/mail review please

fixes #1020