### PR TITLE
Fewer global selectors

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -53,10 +53,12 @@ define(function(require) {
 		};
 	})(), 1000);
 
+	// TODO: create marionette view and encapsulate events
 	$(document).on('click', '#forward-button', function() {
 		Mail.UI.openForwardComposer();
 	});
 
+	// TODO: create marionette view and encapsulate events
 	$(document).on('click', '#mail-message .attachment-save-to-cloud', function(event) {
 		event.stopPropagation();
 		var messageId = $(this).parent().data('messageId');
@@ -64,6 +66,7 @@ define(function(require) {
 		Mail.UI.saveAttachment(messageId, attachmentId);
 	});
 
+	// TODO: create marionette view and encapsulate events
 	$(document).on('click', '#mail-message .attachments-save-to-cloud', function(event) {
 		event.stopPropagation();
 		var messageId = $(this).data('messageId');
@@ -74,6 +77,7 @@ define(function(require) {
 		Mail.UI.openComposer(event);
 	});
 
+	// TODO: create marionette view and encapsulate events
 	// close message when close button is tapped on mobile
 	$(document).on('click', '#mail-message-close', function() {
 		$('#mail-message').addClass('hidden-mobile');
@@ -108,6 +112,7 @@ define(function(require) {
 		}
 	});
 
+	// TODO: create marionette view and encapsulate events
 	// Show the images if wanted
 	$(document).on('click', '#show-images-button', function() {
 		$('#show-images-text').hide();

--- a/js/init.js
+++ b/js/init.js
@@ -83,10 +83,6 @@ define(function(require) {
 		$('#mail-message').addClass('hidden-mobile');
 	});
 
-	$(document).on('show', function() {
-		Mail.UI.changeFavicon(OC.filePath('mail', 'img', 'favicon.png'));
-	});
-
 	// Listens to key strokes, and executes a function based on the key combinations.
 	$(document).keyup(function(event) {
 		// Define which objects to check for the event properties.

--- a/js/init.js
+++ b/js/init.js
@@ -23,8 +23,6 @@ define(function(require) {
 
 	Mail.UI.initializeInterface();
 
-	$(document).on('click', '#mail_new_message', Mail.UI.openComposer);
-
 	/**
 	 * Detects pasted text by browser plugins, and other software.
 	 * Check for changes in message bodies every second.

--- a/js/init.js
+++ b/js/init.js
@@ -1,5 +1,3 @@
-/* global OC */
-
 /**
  * ownCloud - Mail
  *
@@ -7,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @copyright Christoph Wurst 2015
+ * @copyright Christoph Wurst 2015, 2016
  */
 
 define(function(require) {

--- a/js/init.js
+++ b/js/init.js
@@ -83,31 +83,6 @@ define(function(require) {
 		$('#mail-message').addClass('hidden-mobile');
 	});
 
-	// Listens to key strokes, and executes a function based on the key combinations.
-	$(document).keyup(function(event) {
-		// Define which objects to check for the event properties.
-		// (Window object provides fallback for IE8 and lower.)
-		event = event || window.event;
-		var key = event.keyCode || event.which;
-		// If the client is currently viewing a message:
-		if (Mail.State.currentMessageId) {
-			switch (key) {
-				// If delete key is pressed:
-				case 46:
-					// If not composing a reply
-					// and message list is visible (not being in a settings dialog)
-					// and if searchbox is not focused
-					if (!$('.to, .cc, .message-body').is(':focus') &&
-							$('#mail_messages').is(':visible') &&
-							!$('#searchbox').is(':focus')) {
-						// Mimic a client clicking the delete button for the currently active message.
-						$('.mail_message_summary.active .icon-delete.action.delete').click();
-					}
-					break;
-			}
-		}
-	});
-
 	// TODO: create marionette view and encapsulate events
 	// Show the images if wanted
 	$(document).on('click', '#show-images-button', function() {

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -21,9 +21,17 @@ define(function(require) {
 			content: '#app-content',
 			setup: '#setup'
 		},
+                events: {
+                    'click #mail_new_message': 'onNewMessageClick'
+                },
 		initialize: function() {
+			console.log(this.$('#mail_new_message'));
 			this.bindUIElements();
 		},
+                onNewMessageClick: function(e) {
+			e.preventDefault();
+			require('app').UI.openComposer();
+                },
 		render: function() {
 			// This view doesn't need rendering
 		}

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -22,24 +22,51 @@ define(function(require) {
 			content: '#app-content',
 			setup: '#setup'
 		},
-                events: {
+		events: {
 			'click #mail_new_message': 'onNewMessageClick'
-                },
+		},
 		initialize: function() {
 			this.bindUIElements();
+
+			// Global event handlers:
 
 			// Hide notification favicon when switching back from
 			// another browser tab
 			$(document).on('show', this.onDocumentShow);
+
+			// Listens to key strokes, and executes a function based
+			// on the key combinations.
+			$(document).keyup(this.onKeyUp);
 		},
 		onDocumentShow: function(e) {
 			e.preventDefault();
 			require('app').UI.changeFavicon(OC.filePath('mail', 'img', 'favicon.png'));
 		},
-                onNewMessageClick: function(e) {
+		onKeyUp: function(e) {
+			// Define which objects to check for the event properties.
+			// (Window object provides fallback for IE8 and lower.)
+			e = e || window.e;
+			var key = e.keyCode || e.which;
+			// If the client is currently viewing a message:
+			if (require('app').State.currentMessageId) {
+				if (key === 46) {
+					// If delete key is pressed:
+					// If not composing a reply
+					// and message list is visible (not being in a settings dialog)
+					// and if searchbox is not focused
+					if (!$('.to, .cc, .message-body').is(':focus') &&
+						$('#mail_messages').is(':visible') &&
+						!$('#searchbox').is(':focus')) {
+						// Mimic a client clicking the delete button for the currently active message.
+						$('.mail_message_summary.active .icon-delete.action.delete').click();
+					}
+				}
+			}
+		},
+		onNewMessageClick: function(e) {
 			e.preventDefault();
 			require('app').UI.openComposer();
-                },
+		},
 		render: function() {
 			// This view doesn't need rendering
 		}

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -13,6 +13,7 @@ define(function(require) {
 
 	var Marionette = require('marionette');
 	var $ = require('jquery');
+	var OC = require('OC');
 
 	return Marionette.LayoutView.extend({
 		el: $('#app'),
@@ -22,11 +23,18 @@ define(function(require) {
 			setup: '#setup'
 		},
                 events: {
-                    'click #mail_new_message': 'onNewMessageClick'
+			'click #mail_new_message': 'onNewMessageClick'
                 },
 		initialize: function() {
-			console.log(this.$('#mail_new_message'));
 			this.bindUIElements();
+
+			// Hide notification favicon when switching back from
+			// another browser tab
+			$(document).on('show', this.onDocumentShow);
+		},
+		onDocumentShow: function(e) {
+			e.preventDefault();
+			require('app').UI.changeFavicon(OC.filePath('mail', 'img', 'favicon.png'));
 		},
                 onNewMessageClick: function(e) {
 			e.preventDefault();


### PR DESCRIPTION
This moves global selectors into the app-view, because it feels less hacky to me then. I also added some TODOs, where a bigger refactoring is needed.

Some day I would like to fully get rid of hacky files like init.js and ui.js. We should try to encapsulate all view code into view classes instead of global event handlers that nobody really remembers what they are doing :smile: 

@owncloud/mail have a look please. The easiest is to review each of the commits since I tried to do it step-by-step.