### PR TITLE
Add 'bulk mail' as junk/span special folder.

### DIFF
--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -314,7 +314,7 @@ class Mailbox implements IMailBox {
 			'drafts'  => ['draft', 'drafts'],
 			'archive' => ['archive', 'archives'],
 			'trash'   => ['deleted messages', 'trash'],
-			'junk'    => ['junk', 'spam'],
+			'junk'    => ['junk', 'spam', 'bulk mail'],
 		];
 
 		$lowercaseExplode = explode($this->delimiter, $this->getFolderId(), 2);


### PR DESCRIPTION
Yahoo! mail use "Bulk mail" as junk/span and until now is considered a common folder.