### PR TITLE
Speed up unified inbox loading by caching some redundant imap calls

### DIFF
--- a/lib/account.php
+++ b/lib/account.php
@@ -39,6 +39,9 @@ class Account implements IAccount {
 	/** @var MailAccount */
 	private $account;
 
+	/** @var Horde_Imap_Client_Mailbox */
+	private $mailbox;
+
 	/** @var Mailbox[]|null */
 	private $mailboxes;
 
@@ -281,14 +284,18 @@ class Account implements IAccount {
 	 * @return \OCA\Mail\Mailbox
 	 */
 	public function getMailbox($folderId) {
-		$conn = $this->getImapConnection();
-		$parts = explode('/', $folderId);
-		if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
-			$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
-			return new SearchMailbox($conn, $mailbox, []);
+		if ($this->mailbox === null) {
+			$conn = $this->getImapConnection();
+			$parts = explode('/', $folderId);
+			if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
+				$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
+				return new SearchMailbox($conn, $mailbox, []);
+			}
+			$mailbox = new Horde_Imap_Client_Mailbox($folderId);
+			$this->mailbox = new Mailbox($conn, $mailbox, []);
 		}
-		$mailbox = new Horde_Imap_Client_Mailbox($folderId);
-		return new Mailbox($conn, $mailbox, []);
+
+		return $this->mailbox;
 	}
 
 	/**

--- a/lib/account.php
+++ b/lib/account.php
@@ -39,9 +39,6 @@ class Account implements IAccount {
 	/** @var MailAccount */
 	private $account;
 
-	/** @var Horde_Imap_Client_Mailbox */
-	private $mailbox;
-
 	/** @var Mailbox[]|null */
 	private $mailboxes;
 
@@ -284,18 +281,14 @@ class Account implements IAccount {
 	 * @return \OCA\Mail\Mailbox
 	 */
 	public function getMailbox($folderId) {
-		if ($this->mailbox === null) {
-			$conn = $this->getImapConnection();
-			$parts = explode('/', $folderId);
-			if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
-				$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
-				return new SearchMailbox($conn, $mailbox, []);
-			}
-			$mailbox = new Horde_Imap_Client_Mailbox($folderId);
-			$this->mailbox = new Mailbox($conn, $mailbox, []);
+		$conn = $this->getImapConnection();
+		$parts = explode('/', $folderId);
+		if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
+			$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
+			return new SearchMailbox($conn, $mailbox, []);
 		}
-
-		return $this->mailbox;
+		$mailbox = new Horde_Imap_Client_Mailbox($folderId);
+		return new Mailbox($conn, $mailbox, []);
 	}
 
 	/**

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -16,6 +16,7 @@ use OCA\Mail\Http\AttachmentDownloadResponse;
 use OCA\Mail\Http\HtmlResponse;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\ContactsIntegration;
+use OCA\Mail\Service\IAccount;
 use OCA\Mail\Service\IMailBox;
 use OCA\Mail\Service\UnifiedAccount;
 use OCP\AppFramework\Controller;
@@ -425,11 +426,11 @@ class MessagesController extends Controller {
 	 * @param $folderId
 	 * @param $id
 	 * @param $m
-	 * @param $account
+	 * @param IAccount $account
 	 * @param $mailBox
 	 * @return mixed
 	 */
-	private function enhanceMessage($accountId, $folderId, $id, $m, $account, $mailBox) {
+	private function enhanceMessage($accountId, $folderId, $id, $m, IAccount $account, $mailBox) {
 		$json = $m->getFullMessage($account->getEmail(), $mailBox->getSpecialRole());
 		$json['senderImage'] = $this->contactsIntegration->getPhoto($m->getFromEmail());
 		if (isset($json['hasHtmlBody'])) {

--- a/lib/service/unifiedaccount.php
+++ b/lib/service/unifiedaccount.php
@@ -19,6 +19,9 @@ class UnifiedAccount implements IAccount {
 	/** @var IL10N */
 	private $l10n;
 
+	/** @var Horde_Mail_Rfc822_List */
+	private $email;
+
 	/**
 	 * @param AccountService $accountService
 	 * @param string $userId
@@ -104,16 +107,19 @@ class UnifiedAccount implements IAccount {
 	 * @return string
 	 */
 	public function getEmail() {
-		$allAccounts = $this->accountService->findByUserId($this->userId);
-		$addressesList = new \Horde_Mail_Rfc822_List();
-		foreach ($allAccounts as $account) {
-			$inbox = $account->getInbox();
-			if (is_null($inbox)) {
-				continue;
+		if ($this->email === null) {
+			$allAccounts = $this->accountService->findByUserId($this->userId);
+			$addressesList = new \Horde_Mail_Rfc822_List();
+			foreach ($allAccounts as $account) {
+				$inbox = $account->getInbox();
+				if (is_null($inbox)) {
+					continue;
+				}
+				$addressesList->add($account->getEmail());
 			}
-			$addressesList->add($account->getEmail());
+			$this->email = $addressesList;
 		}
-		return $addressesList;
+		return $this->email;
 	}
 
 	/**


### PR DESCRIPTION
Since unified inbox felt kind of slow when initially loading the app after browser cache has been cleared, I had a look at what might cause it. It turned out the uniform inbox implementation re-creates accounts again for each message that is being loaded (bulk message load route). This resulted in 32 imap connections for 2 imap accounts. Moreover, whenever the special folder 'inbox' was queried, the imap server was asked for a list of mailboxes.

I added some in-memory caching to prevent useless calls to the imap server per request. As a result, loading 10 messages of the unified inbox in bulk now takes about 3.9s, where it took 12.8 without those optimizations. 3 instead of 32 imap connections are needed.

@owncloud/mail please test and review this, thanks.