### PR TITLE
add console command for account creation

### DIFF
--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -9,10 +9,10 @@
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @copyright Christoph Wurst 2016
  */
-
-use OC;
 use OCA\Mail\Command\CreateAccount;
 
 $accountService = OC::$server->query('OCA\Mail\Service\AccountService');
+$crypto = OC::$server->getCrypto();
+
 /** @var Symfony\Component\Console\Application $application */
-$application->add(new CreateAccount($accountService));
+$application->add(new CreateAccount($accountService, $crypto));

--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2016
+ */
+
+use OC;
+use OCA\Mail\Command\CreateAccount;
+
+$accountService = OC::$server->query('OCA\Mail\Service\AccountService');
+/** @var Symfony\Component\Console\Application $application */
+$application->add(new CreateAccount($accountService));

--- a/lib/command/createaccount.php
+++ b/lib/command/createaccount.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2016
+ */
+
+namespace OCA\Mail\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AccountService;
+
+class CreateAccount extends Command {
+
+	const ARGUMENT_USER_ID = 'user_id';
+	const ARGUMENT_NAME = 'name';
+	const ARGUMENT_EMAIL = 'email';
+	const ARGUMENT_IMAP_HOST = 'imap_host';
+	const ARGUMENT_IMAP_PORT = 'imap_port';
+	const ARGUMENT_IMAP_SSL_MODE = 'imap_ssl_mode';
+	const ARGUMENT_IMAP_USER = 'imap_user';
+	const ARGUMENT_IMAP_PASSWORD = 'imap_password';
+	const ARGUMENT_SMTP_HOST = 'smtp_host';
+	const ARGUMENT_SMTP_PORT = 'smtp_port';
+	const ARGUMENT_SMTP_SSL_MODE = 'smtp_ssl_mode';
+	const ARGUMENT_SMTP_USER = 'smtp_user';
+	const ARGUMENT_SMTP_PASSWORD = 'smtp_password';
+
+	/** @var AccountService */
+	private $accountService;
+
+	public function __construct(AccountService $service) {
+		parent::__construct();
+
+		$this->accountService = $service;
+	}
+
+	protected function configure() {
+		$this->setName('mail:account:create');
+		$this->setDescription('creates IMAP account');
+		$this->addArgument(self::ARGUMENT_USER_ID, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_NAME, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_EMAIL, InputArgument::REQUIRED);
+
+		$this->addArgument(self::ARGUMENT_IMAP_HOST, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_IMAP_PORT, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_IMAP_SSL_MODE, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_IMAP_USER, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_IMAP_PASSWORD, InputArgument::REQUIRED);
+
+		$this->addArgument(self::ARGUMENT_SMTP_HOST, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_SMTP_PORT, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_SMTP_SSL_MODE, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_SMTP_USER, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_SMTP_PASSWORD, InputArgument::REQUIRED);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$userId = $input->getArgument(self::ARGUMENT_USER_ID);
+		$name = $input->getArgument(self::ARGUMENT_NAME);
+		$email = $input->getArgument(self::ARGUMENT_EMAIL);
+
+		$imapHost = $input->getArgument(self::ARGUMENT_IMAP_HOST);
+		$imapPort = $input->getArgument(self::ARGUMENT_IMAP_PORT);
+		$imapSslMode = $input->getArgument(self::ARGUMENT_IMAP_SSL_MODE);
+		$imapUser = $input->getArgument(self::ARGUMENT_IMAP_USER);
+		$imapPassword = $input->getArgument(self::ARGUMENT_IMAP_PASSWORD);
+
+		$smtpHost = $input->getArgument(self::ARGUMENT_SMTP_HOST);
+		$smtpPort = $input->getArgument(self::ARGUMENT_SMTP_PORT);
+		$smtpSslMode = $input->getArgument(self::ARGUMENT_SMTP_SSL_MODE);
+		$smtpUser = $input->getArgument(self::ARGUMENT_SMTP_USER);
+		$smtpPassword = $input->getArgument(self::ARGUMENT_SMTP_PASSWORD);
+
+		$account = new MailAccount();
+		$account->setUserId($userId);
+		$account->setName($name);
+		$account->setEmail($email);
+
+		$account->setInboundHost($imapHost);
+		$account->setInboundPort($imapPort);
+		$account->setInboundSslMode($imapSslMode);
+		$account->setInboundUser($imapUser);
+		$account->setInboundPassword($imapPassword);
+
+		$account->setOutboundHost($smtpHost);
+		$account->setOutboundPort($smtpPort);
+		$account->setOutboundSslMode($smtpSslMode);
+		$account->setOutboundUser($smtpUser);
+		$account->setOutboundPassword($smtpPassword);
+
+		$this->accountService->save($account);
+
+		$output->writeln("<info>Account $email created");
+	}
+
+}

--- a/lib/command/createaccount.php
+++ b/lib/command/createaccount.php
@@ -16,32 +16,37 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use OCP\Security\ICrypto;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Service\AccountService;
 
 class CreateAccount extends Command {
 
-	const ARGUMENT_USER_ID = 'user_id';
+	const ARGUMENT_USER_ID = 'user-id';
 	const ARGUMENT_NAME = 'name';
 	const ARGUMENT_EMAIL = 'email';
-	const ARGUMENT_IMAP_HOST = 'imap_host';
-	const ARGUMENT_IMAP_PORT = 'imap_port';
-	const ARGUMENT_IMAP_SSL_MODE = 'imap_ssl_mode';
-	const ARGUMENT_IMAP_USER = 'imap_user';
-	const ARGUMENT_IMAP_PASSWORD = 'imap_password';
-	const ARGUMENT_SMTP_HOST = 'smtp_host';
-	const ARGUMENT_SMTP_PORT = 'smtp_port';
-	const ARGUMENT_SMTP_SSL_MODE = 'smtp_ssl_mode';
-	const ARGUMENT_SMTP_USER = 'smtp_user';
-	const ARGUMENT_SMTP_PASSWORD = 'smtp_password';
+	const ARGUMENT_IMAP_HOST = 'imap-host';
+	const ARGUMENT_IMAP_PORT = 'imap-port';
+	const ARGUMENT_IMAP_SSL_MODE = 'imap-ssl-mode';
+	const ARGUMENT_IMAP_USER = 'imap-user';
+	const ARGUMENT_IMAP_PASSWORD = 'imap-password';
+	const ARGUMENT_SMTP_HOST = 'smtp-host';
+	const ARGUMENT_SMTP_PORT = 'smtp-port';
+	const ARGUMENT_SMTP_SSL_MODE = 'smtp-ssl-mode';
+	const ARGUMENT_SMTP_USER = 'smtp-user';
+	const ARGUMENT_SMTP_PASSWORD = 'smtp-password';
 
 	/** @var AccountService */
 	private $accountService;
 
-	public function __construct(AccountService $service) {
+	/** @var \OCP\Security\ICrypto */
+	private $crypto;
+
+	public function __construct(AccountService $service, ICrypto $crypto) {
 		parent::__construct();
 
 		$this->accountService = $service;
+		$this->crypto = $crypto;
 	}
 
 	protected function configure() {
@@ -90,17 +95,17 @@ class CreateAccount extends Command {
 		$account->setInboundPort($imapPort);
 		$account->setInboundSslMode($imapSslMode);
 		$account->setInboundUser($imapUser);
-		$account->setInboundPassword($imapPassword);
+		$account->setInboundPassword($this->crypto->encrypt($imapPassword));
 
 		$account->setOutboundHost($smtpHost);
 		$account->setOutboundPort($smtpPort);
 		$account->setOutboundSslMode($smtpSslMode);
 		$account->setOutboundUser($smtpUser);
-		$account->setOutboundPassword($smtpPassword);
+		$account->setOutboundPassword($this->crypto->encrypt($smtpPassword));
 
 		$this->accountService->save($account);
 
-		$output->writeln("<info>Account $email created");
+		$output->writeln("<info>Account $email created</info>");
 	}
 
 }

--- a/tests/command/createaccounttest.php
+++ b/tests/command/createaccounttest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * ownCloud - Mail
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Christoph Wurst 2016
+ */
+
+namespace OCA\Mail\Tests\Command;
+
+use PHPUnit_Framework_TestCase;
+use OCA\Mail\Command\CreateAccount;
+
+class CreateAccountTest extends PHPUnit_Framework_TestCase {
+
+	private $service;
+	private $crypto;
+	private $command;
+	private $args = [
+		'user-id',
+		'name',
+		'email',
+		'imap-host',
+		'imap-port',
+		'imap-ssl-mode',
+		'imap-user',
+		'imap-password',
+		'smtp-host',
+		'smtp-port',
+		'smtp-ssl-mode',
+		'smtp-user',
+		'smtp-password',
+	];
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->service = $this->getMockBuilder('\OCA\Mail\Service\AccountService')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->crypto = $this->getMock('\OCP\Security\ICrypto');
+
+		$this->command = new CreateAccount($this->service, $this->crypto);
+	}
+
+	public function testName() {
+		$this->assertSame('mail:account:create', $this->command->getName());
+	}
+
+	public function testDescription() {
+		$this->assertSame('creates IMAP account', $this->command->getDescription());
+	}
+
+	public function testArguments() {
+		$actual = $this->command->getDefinition()->getArguments();
+
+		foreach ($actual as $actArg) {
+			$this->assertTrue($actArg->isRequired());
+			$this->assertTrue(in_array($actArg->getName(), $this->args));
+		}
+	}
+
+}


### PR DESCRIPTION
This adds a simple command as described in #1125.

implements #1125 

TODO:
- [x] encrypt passwords
- [x] add unit test

@DeepDiver1975 @hitam4450 @owncloud/mail 