### PR TITLE
remove cyclic dependency from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install-npm-deps-dev:
 install-bower-deps: bower.json install-npm-deps
 	./node_modules/bower/bin/bower install
 
-optimize-js: install-deps
+optimize-js: install-npm-deps install-bower-deps
 	./node_modules/requirejs/bin/r.js -o build.js
 
 dev-setup: install-composer-deps install-npm-deps-dev install-bower-deps


### PR DESCRIPTION
This resolves the issues of unnecessarily installing composer dependencies when trying to optimize javascript files.

@owncloud/mail review please

This target is executed either directly or when packaging the app for the appstore, where dependencies are installed anyway.