### PR TITLE
update backbone, backbone.marionette

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {
     "autosize": "jquery-autosize#1.18.9",
-    "backbone": "1.1.2",
-    "backbone.marionette": "~2.4.2",
+    "backbone": "^1.2.3",
+    "backbone.marionette": "^2.4.4",
     "domready": "~1.0.8",
     "handlebars": "~3.0.3",
     "jquery": "~2.1.4",


### PR DESCRIPTION
updates backbone from 1.1.2 to 1.2.3
and marionette from 2.4.2 to 2.4.4