### PR TITLE
fix templates

### DIFF
--- a/templates/error.php
+++ b/templates/error.php
@@ -19,6 +19,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+?>
+<?php /** @var array $_ */?>
+<?php /** @var \OCP\IL10N $l */?>
 <div class="error">
 	<legend><strong><?php p($l->t('Error loading message'));?></strong></legend>
 	<p><?php p($_['message']); ?></p>

--- a/templates/redirect.php
+++ b/templates/redirect.php
@@ -20,6 +20,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+?>
+<?php /** @var array $_ */?>
+<?php if (isset($_['authorizedRedirect']) && ($_['authorizedRedirect'])): ?>
+	<?php script('mail', 'autoredirect'); ?>
 	<div class="error" style="text-align: center;">
 		<img src="<?php p(\OCP\Util::imagePath('core', 'loading-dark.gif'));?>"
 			style="margin: 0 auto;" />


### PR DESCRIPTION
I saw those erros on travis:
```
PHP Parse error:  syntax error, unexpected '<' in ./templates/error.php on line 22

Parse error: syntax error, unexpected '<' in ./templates/error.php on line 22

Errors parsing ./templates/error.php

No syntax errors detected in ./templates/index.php

PHP Parse error:  syntax error, unexpected '<' in ./templates/redirect.php on line 23

Parse error: syntax error, unexpected '<' in ./templates/redirect.php on line 23

Errors parsing ./templates/redirect.php
```

this was caused by PR #1277

@owncloud/mail @ErikPel easy to review