### PR TITLE
Add imap docker for faster CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 language: php
 php:
   - 5.4
@@ -6,12 +7,21 @@ php:
   - 5.6
   - 7
 
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
+
+services:
+  - docker
+  - postgresql
+
 env:
   global:
     - CORE_BRANCH=master
     - TEST_JS=FALSE
-    - secure: AaTeRG3kL/LeMOcMgul08EUBM7Kdtrkz9EAGPauKdxXbxggP0j5SxN8ciYxc8CiVni0CYJofW07YjG6tXqhvHeMINHx8Q+5KUUfiLwNrLgl1sMkh7vPR9EA5Z1Y8Nz4N1Qt7zxpqWKPHUsjUNFWxP2TPHEq2FEOGeKbsI7GOYas=
-    - secure: S5agbWaWSLgbujsVhZB9WkCAM0ris8uh9hPnspYw48bolkMhknJ7JxOWGV4rOcJ52kdOgifFRE9XYi65RFLL8zuaZDBU2zFoXO3fpatziYEiIWnxVrkogw1pnh/FeRnrUld+QDykFyUcfSGdFRw5R5FuZHrxe+Q5bHfiEjh4hlE=
   matrix:
     - DB=sqlite
 
@@ -27,8 +37,22 @@ cache:
     - $HOME/.cache/bower
 
 before_install:
+    # No 'travis' mysql on trusty beta -> create it
+  - mysql -u root -e "CREATE USER 'travis'@'localhost'"
+  - mysql -u root -e "GRANT ALL ON *.* TO 'travis'@'localhost';"
+
+    # Get old phpunit that supports php 5.4
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.4' ]; then curl -s -o $HOME/.phpenv/versions/5.4/bin/phpunit https://phar.phpunit.de/phpunit-4.8.9.phar; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.4' ]; then chmod +x $HOME/.phpenv/versions/5.4/bin/phpunit; fi"
+
+    # Install dependencies
   - composer self-update
   - make install-composer-deps
+
+    # Pull and start imap docker
+  - make start-imap-docker
+
+    # Core setup
   - wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh
   - bash ./before_install.sh mail $CORE_BRANCH $DB
   - cd ../core
@@ -38,6 +62,7 @@ before_install:
 before_script:
   - cd apps/mail
   - sh -c "if [ '$TEST_JS' = 'TRUE' ]; then make dev-setup; fi"
+  - make add-imap-account
 
 script:
   # Test lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   global:
     - CORE_BRANCH=master
     - TEST_JS=FALSE
+    - PHP_COVERAGE=FALSE
   matrix:
     - DB=sqlite
 
@@ -63,6 +64,8 @@ before_script:
   - cd apps/mail
   - sh -c "if [ '$TEST_JS' = 'TRUE' ]; then make dev-setup; fi"
   - make add-imap-account
+    # Disable xdebug if it's not needed
+  - if [[ "$PHP_COVERAGE" = "FALSE" ]]; then phpenv config-rm xdebug.ini; fi
 
 script:
   # Test lint
@@ -76,14 +79,14 @@ script:
   - phpunit --configuration phpunit.xml
 
   # Create coverage report
-  - sh -c "wget https://scrutinizer-ci.com/ocular.phar"
-  - sh -c "php ocular.phar code-coverage:upload --format=php-clover clover.xml"
+  - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then php ocular.phar code-coverage:upload --format=php-clover clover.xml; fi
 matrix:
   include:
     - php: 5.4
       env: "DB=mysql TEST_JS=TRUE"
     - php: 5.4
-      env: DB=pgsql
+      env: "DB=pgsql PHP_COVERAGE=TRUE"
     - php: 5.4
       env: "DB=mysql CORE_BRANCH=stable8"
     - php: 5.4

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ build_dir=$(CURDIR)/build/artifacts
 appstore_dir=$(build_dir)/appstore
 source_dir=$(build_dir)/source
 package_name=$(app_name)
+docker_image=christophwurst/owncloud-mail-test-docker
+mail_user=user@domain.tld
+mail_pwd=mypassword
 
 all: appstore
 
@@ -35,6 +38,15 @@ optimize-js: install-npm-deps install-bower-deps
 	./node_modules/requirejs/bin/r.js -o build.js
 
 dev-setup: install-composer-deps install-npm-deps-dev install-bower-deps
+
+start-imap-docker:
+	docker pull $(docker_image)
+	docker run --name="ocimaptest" -d \
+	-p 2525:25 -p 587:587 -p 993:993 \
+	-e POSTFIX_HOSTNAME=mail.domain.tld $(docker_image)
+
+add-imap-account:
+	docker exec -it ocimaptest /opt/bin/useradd $(mail_user) $(mail_pwd)
 
 update-composer:
 	rm -f composer.lock

--- a/tests/imap/abstracttest.php
+++ b/tests/imap/abstracttest.php
@@ -39,34 +39,23 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase {
 	private static $createdMailboxes = [];
 
 	public static function setUpBeforeClass() {
-		if (false === \getenv('EMAIL_USER')) {
-			throw new \PHPUnit_Framework_SkippedTestError(
-				'Please set environment variable EMAIL_USER before running functional tests'
-			);
-		}
-
-		if (false === \getenv('EMAIL_PASSWORD')) {
-			throw new \PHPUnit_Framework_SkippedTestError(
-				'Please set environment variable EMAIL_PASSWORD before running functional tests'
-			);
-		}
-		$user = \getenv('EMAIL_USER');
-		$password = \getenv('EMAIL_PASSWORD');
+		$user = 'user@domain.tld';
+		$password = 'mypassword';
 		$password = \OC::$server->getCrypto()->encrypt($password);
 		$a = new MailAccount();
 		$a->setId(-1);
 		$a->setName('ownCloudMail');
-		$a->setInboundHost('imap.gmail.com');
+		$a->setInboundHost('localhost');
 		$a->setInboundPort(993);
 		$a->setInboundUser($user);
 		$a->setInboundPassword($password);
 		$a->setInboundSslMode('ssl');
 		$a->setEmail($user);
-		$a->setOutboundHost('smtp.gmail.com');
+		$a->setOutboundHost('localhost');
 		$a->setOutboundPort(465);
 		$a->setOutboundUser($user);
 		$a->setOutboundPassword($password);
-		$a->setOutboundSslMode('ssl');
+		$a->setOutboundSslMode('none');
 
 		self::$account = new Account($a);
 		self::$account->getImapConnection();


### PR DESCRIPTION
fixes #1291

- Uses trusty beta instead of docker based infrastructure
  - it is needed for running docker images
  - MySQL has to be installed explicitly as it's not yet included
- Makefile is used for starting/managing the imap docker
- This can be used locally by all developers
- **phpunit now needs 2-3 seconds instead of 70** as the IMAP server is run locally and xdebug is disabled if not needed

## Comparison
Before (last master build):
![bildschirmfoto von 2016-02-17 11-47-45](https://cloud.githubusercontent.com/assets/1374172/13107133/776aab1c-d56c-11e5-9107-d976989b0e8b.png)
After (this PR):
![bildschirmfoto von 2016-02-17 11-47-06](https://cloud.githubusercontent.com/assets/1374172/13107146/86ca7f6a-d56c-11e5-891f-b4840835b201.png)
Summing up, it's 34:40 vs. 13:42. However, that's not all – the docker based version can also be run concurrently! 

@owncloud/mail have a look at this :rocket: 