### PR TITLE
reduce width of account indicator bar from 5 to 2px

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -178,7 +178,7 @@
 
 .mail-message-account-color {
 	position: absolute;
-	width: 5px;
+	width: 2px;
 	height: 69px;
 	z-index: 1;
 }


### PR DESCRIPTION
Please review @owncloud/mail, fix #1241