### PR TITLE
Allow composer to use http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+	"config": {
+		"secure-http": false
+	},
 	"repositories": [
 		{
 			"type": "pear",


### PR DESCRIPTION
Fixes the following composer error:
>   Installing pear-pear.horde.org/horde_translation (2.2.1)
>
>    Downloading: Connecting...    Downloading: Connecting...    Downloading: Connecting...
>
>                                                                               
>
>  [Composer\Downloader\TransportException]                                     
>
>  Your configuration does not allow connection to http://pear.horde.org. See   
>
>  https://getcomposer.org/doc/06-config.md#secure-http for details.            


https://travis-ci.org/owncloud/mail/jobs/111795408, https://github.com/owncloud/mail/pull/1324

@jancborchardt @owncloud/mail review please