### PR TITLE
don't hide date on mobile, list view exactly as on desktop

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -59,17 +59,5 @@
 	width: 100%;
 }
 
-/* do not display date in message list because there is too little space */
-.date {
-	display: none;
-}
-/* more space for sender accordingly */
-.mail-message-summary-from {
-	width: 80%;
-}
-.mail-message-summary-subject {
-	width: 80%;
-}
-
 /* end of media query */
 }


### PR DESCRIPTION
I found myself frequently missing the date of the mail when on mobile. There’s no real reason to hide it as usually there’s plenty of space right to the sender. So the elements are now just like on the desktop.

Please review @owncloud/designers @owncloud/mail