### PR TITLE
use LoadingView instead of manually adding/removing classes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,7 @@ define(function(require) {
 	// Load controllers/services
 	require('controller/accountcontroller');
 	require('controller/foldercontroller');
+	require('controller/messagecontroller');
 	require('service/accountservice');
 	require('service/folderservice');
 	require('notification');

--- a/js/app.js
+++ b/js/app.js
@@ -26,10 +26,14 @@ define(function(require) {
 	var Mail = new Marionette.Application();
 
 	Mail.on('start', function() {
+		Radio.ui.trigger('navigation:loading');
+		Radio.ui.trigger('content:loading');
 		Radio.account.trigger('load');
 	});
 
-	Mail.view = new AppView();
+	Mail.view = new AppView({
+		el: '#app'
+	});
 
 	return Mail;
 });

--- a/js/background.js
+++ b/js/background.js
@@ -139,7 +139,7 @@ define(function(require) {
 							Cache.addMessageList(changedAccount, localFolder, cachedList);
 						}
 
-						State.folderView.updateTitle();
+						Radio.ui.trigger('title:update');
 					});
 				}
 			});

--- a/js/controller/accountcontroller.js
+++ b/js/controller/accountcontroller.js
@@ -39,7 +39,7 @@ define(function(require) {
 			} else {
 				var firstAccount = accounts.at(0);
 				accounts.each(function(account) {
-					Radio.folder.trigger('init', account, firstAccount);
+					Radio.folder.trigger('load', account, firstAccount);
 				});
 			}
 
@@ -49,8 +49,4 @@ define(function(require) {
 			Radio.ui.trigger('error:show', t('mail', 'Error while loading the accounts.'));
 		});
 	}
-
-	return {
-		loadAccounts: loadAccounts
-	};
 });

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -77,10 +77,6 @@ define(function(require) {
 	function loadFolder(account, active) {
 		var fetchingFolders = FolderService.getFolderEntities(account);
 
-		// TODO: create loading-view
-		$('#mail-messages').addClass('icon-loading');
-		$('#mail-message').addClass('icon-loading');
-
 		Radio.ui.trigger('messagesview:messages:reset');
 		$('#app-navigation').addClass('icon-loading');
 

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -16,7 +16,7 @@ define(function(require) {
 	var Radio = require('radio');
 	var FolderService = require('service/folderservice');
 
-	Radio.folder.on('init', loadFolder);
+	Radio.folder.on('load', loadFolder);
 
 	function urldecode(str) {
 		return decodeURIComponent((str + '').replace(/\+/g, '%20'));
@@ -78,10 +78,10 @@ define(function(require) {
 		var fetchingFolders = FolderService.getFolderEntities(account);
 
 		Radio.ui.trigger('messagesview:messages:reset');
-		$('#app-navigation').addClass('icon-loading');
 
 		$.when(fetchingFolders).done(function(accountFolders) {
-			$('#app-navigation').removeClass('icon-loading');
+			// TODO: trigger when ALL accounts have been loaded
+			Radio.ui.trigger('navigation:show');
 
 			if (account === active) {
 				var folder = accountFolders.at(0);

--- a/js/controller/messagecontroller.js
+++ b/js/controller/messagecontroller.js
@@ -1,0 +1,105 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var $ = require('jquery');
+	var _ = require('underscore');
+	var Radio = require('radio');
+
+	Radio.message.on('load', function(account, folder, messageId, options) {
+		//FIXME: don't rely on global state vars
+		load(account, messageId, options);
+	});
+
+	/**
+	 * @param {Account} account
+	 * @param {number} messageId
+	 * @param {object} options
+	 * @returns {undefined}
+	 */
+	function load(account, messageId, options) {
+		options = options || {};
+		var defaultOptions = {
+			force: false
+		};
+		_.defaults(options, defaultOptions);
+
+		// Do not reload email when clicking same again
+		if (require('state').currentMessageId === messageId) {
+			return;
+		}
+
+		Radio.ui.trigger('composer:leave');
+
+		if (!options.force && require('ui').isComposerVisible()) {
+			return;
+		}
+		// Abort previous loading requests
+		if (require('state').messageLoading !== null) {
+			require('state').messageLoading.abort();
+		}
+
+		// check if message is a draft
+		var draftsFolder = account.get('specialFolders').drafts;
+		var draft = draftsFolder === require('state').currentFolder.get('id');
+
+		// close email first
+		// Check if message is open
+		if (require('state').currentMessageId !== null) {
+			var lastMessageId = require('state').currentMessageId;
+			Radio.ui.trigger('messagesview:message:setactive', null);
+			if (lastMessageId === messageId) {
+				return;
+			}
+		}
+
+		Radio.ui.trigger('message:loading');
+
+		// Set current Message as active
+		Radio.ui.trigger('messagesview:message:setactive', messageId);
+		require('state').currentMessageBody = '';
+
+		// Fade out the message composer
+		$('#mail_new_message').prop('disabled', false);
+
+		require('communication').fetchMessage(
+			require('state').currentAccount,
+			require('state').currentFolder,
+			messageId,
+			{
+				onSuccess: function(message) {
+					if (draft) {
+						Radio.ui.trigger('composer:show', message);
+					} else {
+						require('cache').addMessage(require('state').currentAccount,
+							require('state').currentFolder,
+							message);
+						Radio.ui.trigger('message:show', message);
+					}
+				},
+				onError: function(jqXHR, textStatus) {
+					if (textStatus !== 'abort') {
+						Radio.ui.trigger('error:show', t('mail', 'Error while loading the selected message.'));
+					}
+				}
+			});
+	}
+});

--- a/js/service/folderservice.js
+++ b/js/service/folderservice.js
@@ -38,7 +38,7 @@ define(function(require) {
 				}
 			}
 
-			require('state').folderView.collection.add(account);
+			require('state').accounts.add(account);
 			defer.resolve(account.get('folders'));
 		});
 

--- a/js/templates/navigation.html
+++ b/js/templates/navigation.html
@@ -1,0 +1,11 @@
+<ul>
+	<li id="mail-new-message-fixed"></li>
+	<li id="app-navigation-accounts"></li>
+</ul>
+<div id="app-settings">
+	<div id="app-settings-header">
+		<button class="settings-button"
+			data-apps-slide-toggle="#app-settings-content"></button>
+	</div>
+	<div id="app-settings-content"></div>
+</div>

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -18,10 +18,12 @@ define(function(require) {
 	var MessageContentView = require('views/messagecontent');
 	var NavigationAccountsView = require('views/navigation-accounts');
 	var SettingsView = require('views/settings');
+	var LoadingView = require('views/loadingview');
 	var NavigationView = require('views/navigation');
 	var SetupView = require('views/setup');
 
 	var ContentType = Object.freeze({
+		LOADING: -1,
 		MESSAGE_CONTENT: 0,
 		SETUP: 1
 	});
@@ -44,6 +46,7 @@ define(function(require) {
 			this.listenTo(Radio.ui, 'error:show', this.showError);
 			this.listenTo(Radio.ui, 'setup:show', this.showSetup);
 			this.listenTo(Radio.ui, 'messagecontent:show', this.showMessageContent);
+			this.listenTo(Radio.ui, 'content:loading', this.showContentLoading);
 
 			// Hide notification favicon when switching back from
 			// another browser tab
@@ -118,7 +121,6 @@ define(function(require) {
 			OC.Notification.showTemporary(message);
 			$('#app-navigation').removeClass('icon-loading');
 			$('#app-content').removeClass('icon-loading');
-			$('#mail-message').removeClass('icon-loading');
 			$('#mail_message').removeClass('icon-loading');
 		},
 		showSetup: function() {
@@ -140,6 +142,12 @@ define(function(require) {
 				this.accountsView.listenTo(messageContentView.messages, 'change:unseen',
 					accountsView.changeUnseen);
 				this.content.show(messageContentView);
+			}
+		},
+		showContentLoading: function() {
+			if (this.activeContent !== ContentType.LOADING) {
+				this.activeContent = ContentType.LOADING;
+				this.content.show(new LoadingView());
 			}
 		}
 	});

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -16,8 +16,6 @@ define(function(require) {
 	var OC = require('OC');
 	var Radio = require('radio');
 	var MessageContentView = require('views/messagecontent');
-	var NavigationAccountsView = require('views/navigation-accounts');
-	var SettingsView = require('views/settings');
 	var LoadingView = require('views/loadingview');
 	var NavigationView = require('views/navigation');
 	var SetupView = require('views/setup');
@@ -29,7 +27,6 @@ define(function(require) {
 	});
 
 	var AppView = Marionette.LayoutView.extend({
-		el: $('#app'),
 		accountsView: null,
 		activeContent: null,
 		regions: {
@@ -46,6 +43,8 @@ define(function(require) {
 			this.listenTo(Radio.ui, 'error:show', this.showError);
 			this.listenTo(Radio.ui, 'setup:show', this.showSetup);
 			this.listenTo(Radio.ui, 'messagecontent:show', this.showMessageContent);
+			this.listenTo(Radio.ui, 'navigation:loading', this.showNavigationLoading);
+			this.listenTo(Radio.ui, 'navigation:show', this.showNavigation);
 			this.listenTo(Radio.ui, 'content:loading', this.showContentLoading);
 
 			// Hide notification favicon when switching back from
@@ -57,21 +56,6 @@ define(function(require) {
 			$(document).keyup(this.onKeyUp);
 
 			window.addEventListener('resize', this.onWindowResize);
-
-			// Render settings menu
-			this.navigation = new NavigationView({
-				accounts: require('state').accounts
-			});
-			this.navigation.settings.show(new SettingsView({
-				accounts: require('state').accounts
-			}));
-
-			// setup folder view
-			this.accountsView = new NavigationAccountsView();
-			require('state').folderView = this.accountsView;
-			this.navigation.accounts.show(this.accountsView);
-
-			this.showMessageContent();
 		},
 		onDocumentShow: function(e) {
 			e.preventDefault();
@@ -138,11 +122,17 @@ define(function(require) {
 				this.activeContent = ContentType.MESSAGE_CONTENT;
 
 				var messageContentView = new MessageContentView();
-				var accountsView = this.accountsView;
-				this.accountsView.listenTo(messageContentView.messages, 'change:unseen',
+				var accountsView = this.navigation.currentView.accounts;
+				accountsView.listenTo(messageContentView.messages, 'change:unseen',
 					accountsView.changeUnseen);
 				this.content.show(messageContentView);
 			}
+		},
+		showNavigation: function() {
+			this.navigation.show(new NavigationView());
+		},
+		showNavigationLoading: function() {
+			this.navigation.show(new LoadingView());
 		},
 		showContentLoading: function() {
 			if (this.activeContent !== ContentType.LOADING) {

--- a/js/views/loadingview.js
+++ b/js/views/loadingview.js
@@ -1,0 +1,34 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Marionette = require('marionette');
+
+	/**
+	 * @class LoadingView
+	 */
+	var LoadingView = Marionette.ItemView.extend({
+		template: false,
+		className: 'icon-loading container'
+	});
+
+	return LoadingView;
+});

--- a/js/views/messagecontent.js
+++ b/js/views/messagecontent.js
@@ -20,6 +20,7 @@ define(function(require) {
 	var ComposerView = require('views/composer');
 	var MessageView = require('views/message');
 	var MessagesView = require('views/messages');
+	var LoadingView = require('views/loadingview');
 	var MessageContentTemplate = require('text!templates/messagecontent.html');
 
 	var DetailView = Object.freeze({
@@ -49,7 +50,7 @@ define(function(require) {
 			});
 			// END TODO
 
-			//TODO: this.listenTo(Radio.ui, 'message:loading', this.onMessageLoading);
+			this.listenTo(Radio.ui, 'message:loading', this.onMessageLoading);
 		},
 		onShow: function() {
 			this.messages.show(new MessagesView());
@@ -73,7 +74,6 @@ define(function(require) {
 			if (require('state').messageLoading !== null) {
 				require('state').messageLoading.abort();
 				$('iframe').parent().removeClass('icon-loading');
-				$('#mail-message').removeClass('icon-loading');
 				$('#mail_message').removeClass('icon-loading');
 			}
 
@@ -127,6 +127,9 @@ define(function(require) {
 					}
 				}
 			}
+		},
+		onMessageLoading: function() {
+			this.message.show(new LoadingView());
 		}
 	});
 });

--- a/js/views/messages.js
+++ b/js/views/messages.js
@@ -92,8 +92,7 @@ define(function(require) {
 			}
 
 			require('state').currentMessageId = messageId;
-			require('state').folderView.updateTitle();
-
+			Radio.ui.trigger('title:update');
 		},
 		loadNew: function() {
 			if (!require('state').currentAccount) {

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -75,7 +75,7 @@ define(function(require) {
 			var account = require('state').currentAccount;
 			var folder = require('state').currentFolder;
 			var messageId = this.model.id; //TODO: backbone property
-			Radio.ui.trigger('message:load', account, folder, messageId, {
+			Radio.message.trigger('load', account, folder, messageId, {
 				force: true
 			});
 		},
@@ -103,7 +103,7 @@ define(function(require) {
 						var account = require('state').currentAccount;
 						var folder = require('state').currentFolder;
 						var messageId = nextMessage.id; //TODO: backbone property
-						Radio.ui.trigger('message:load', account, folder, messageId);
+						Radio.message.trigger('load', account, folder, messageId);
 					}
 				}
 				// manually trigger mouseover event for current mouse position

--- a/js/views/navigation-accounts.js
+++ b/js/views/navigation-accounts.js
@@ -17,7 +17,6 @@ define(function(require) {
 	var $ = require('jquery');
 	var Marionette = require('marionette');
 	var AccountView = require('views/account');
-	var AccountCollection = require('models/accountcollection');
 	var Radio = require('radio');
 
 	/**
@@ -30,9 +29,8 @@ define(function(require) {
 		 * @returns {undefined}
 		 */
 		initialize: function() {
-			this.collection = new AccountCollection();
-
 			this.listenTo(Radio.ui, 'folder:changed', this.onFolderChanged);
+			this.listenTo(Radio.ui, 'title:update', this.updateTitle);
 			this.listenTo(Radio.folder, 'setactive', this.setFolderActive);
 		},
 		/**
@@ -84,14 +82,14 @@ define(function(require) {
 		setFolderActive: function(account, folder) {
 			Radio.ui.trigger('messagesview:filter:clear');
 
+			if (_.isUndefined(account)) {
+				return;
+			}
+
 			// disable all other folders for all accounts
 			require('state').accounts.each(function(acnt) {
-				var localAccount = require('state').folderView.collection.get(acnt.get('accountId'));
-				if (_.isUndefined(localAccount)) {
-					return;
-				}
-				var folders = localAccount.get('folders');
-				_.each(folders.models, function(folder) {
+				var folders = acnt.get('folders');
+				folders.each(function(folder) {
 					folders.get(folder).set('active', false);
 				});
 			});

--- a/js/views/navigation.js
+++ b/js/views/navigation.js
@@ -13,32 +13,44 @@ define(function(require) {
 
 	var $ = require('jquery');
 	var Marionette = require('marionette');
+	var Handlebars = require('handlebars');
 	var Radio = require('radio');
 	var NewMessageView = require('views/newmessage');
+	var NavigationAccountsView = require('views/navigation-accounts');
+	var SettingsView = require('views/settings');
+	var NavigationTemplate = require('text!templates/navigation.html');
 
 	return Marionette.LayoutView.extend({
-		el: $('#app-navigation'),
+		template: Handlebars.compile(NavigationTemplate),
 		regions: {
 			newMessage: '#mail-new-message-fixed',
 			accounts: '#app-navigation-accounts',
 			settings: '#app-settings-content'
 		},
 		initialize: function(options) {
-			this.bindUIElements();
-
-			this.newMessage.show(new NewMessageView({
-				accounts: options.accounts
-			}));
-
 			this.listenTo(Radio.ui, 'navigation:show', this.show);
 			this.listenTo(Radio.ui, 'navigation:hide', this.hide);
-		},
-		render: function() {
-			// This view doesn't need rendering
 		},
 		show: function() {
 			this.$el.show();
 			$('#app-navigation-toggle').css('background-image', '');
+		},
+		onShow: function() {
+			var accounts = require('state').accounts;
+			// setup new message view
+			this.newMessage.show(new NewMessageView({
+				accounts: accounts
+			}));
+
+			// setup folder view
+			this.accounts.show(new NavigationAccountsView({
+				collection: accounts
+			}));
+
+			// setup settings view
+			this.settings.show(new SettingsView({
+				accounts: accounts
+			}));
 		},
 		hide: function() {
 			// TODO: move if or rename function

--- a/templates/index.php
+++ b/templates/index.php
@@ -48,18 +48,6 @@ if ($debug) {
 <div id="user-email"
      style="display: none"><?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?></div>
 <div id="app">
-	<div id="app-navigation" class="icon-loading">
-		<ul>
-			<li id="mail-new-message-fixed"></li>
-			<li id="app-navigation-accounts"></li>
-		</ul>
-		<div id="app-settings">
-			<div id="app-settings-header">
-				<button class="settings-button"
-					data-apps-slide-toggle="#app-settings-content"></button>
-			</div>
-			<div id="app-settings-content"></div>
-		</div>
-	</div>
+	<div id="app-navigation"></div>
 	<div id="app-content"></div>
 </div>


### PR DESCRIPTION
Now there's also a single spinner when loading a folder for the first time instead of two.

fixes #1025 

TODO:
 - [x] use LoadingView as a replacement for the NavigationView loading spinner
 - [ ] fix broken SettingsView (core's slide js magic does not work if the html of the settings menu is not present at page load)
 - [ ] add missing LoadingView before accounts have been loaded (https://github.com/owncloud/mail/pull/1399#issuecomment-204666363)

@jancborchardt @Gomez @tahaalibra could you try this branch and tell me if there's anything I forgot? I'm not 100% sure if the changes cover all possible transitions between the UI's states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/owncloud/mail/1399)
<!-- Reviewable:end -->
