### PR TITLE
Improves autoconfig by querying different mozilla isp sources

### DIFF
--- a/lib/service/autoconfig/autoconfig.php
+++ b/lib/service/autoconfig/autoconfig.php
@@ -36,8 +36,8 @@ class AutoConfig {
 	/** @var ICrypto */
 	private $crypto;
 
-	/** @var MozillaIspDb */
-	private $mozillaIspDb;
+	/** @var IspDb */
+	private $ispDb;
 
 	/** @var MxRecord */
 	private $mxRecord;
@@ -61,7 +61,7 @@ class AutoConfig {
 	 * 
 	 * @param Logger $logger
 	 * @param string $UserId
-	 * @param MozillaIspDb $mozillaIspDb
+	 * @param IspDb $ispDb
 	 * @param MxRecord $mxRecord
 	 * @param ImapConnectivityTester $imapTester
 	 * @param ImapServerDetector $imapDetector
@@ -71,14 +71,14 @@ class AutoConfig {
 	 * @param ICrypto $crypto
 	 */
 	public function __construct(Logger $logger, $UserId,
-		MozillaIspDb $mozillaIspDb, MxRecord $mxRecord,
+		IspDb $ispDb, MxRecord $mxRecord,
 		ImapConnectivityTester $imapTester, ImapServerDetector $imapDetector,
 		SmtpConnectivityTester $smtpTester, SmtpServerDetector $smtpDetector,
 		ImapConnector $imapConnector, ICrypto $crypto) {
 		$this->logger = $logger;
 		$this->userId = $UserId;
 		$this->crypto = $crypto;
-		$this->mozillaIspDb = $mozillaIspDb;
+		$this->ispDb = $ispDb;
 		$this->mxRecord = $mxRecord;
 		$this->imapConnectivityTester = $imapTester;
 		$this->imapServerDetector = $imapDetector;
@@ -99,7 +99,7 @@ class AutoConfig {
 		// TODO: use horde libs for email address parsing
 		list(, $host) = explode("@", $email);
 
-		$ispdb = $this->mozillaIspDb->query($host);
+		$ispdb = $this->ispDb->query($host);
 		if (!empty($ispdb)) {
 			$account = null;
 			if (isset($ispdb['imap'])) {

--- a/lib/service/autoconfig/ispdb.php
+++ b/lib/service/autoconfig/ispdb.php
@@ -37,7 +37,8 @@ class IspDb {
 	private function queryUrl($url) {
 		try {
 			$xml = @simplexml_load_file($url);
-			if (!is_object($xml) || !$xml->emailProvider) {
+			if (libxml_get_last_error() !== False || !is_object($xml) || !$xml->emailProvider) {
+				libxml_clear_errors();
 				return [];
 			}
 			$provider = [

--- a/lib/service/autoconfig/ispdb.php
+++ b/lib/service/autoconfig/ispdb.php
@@ -21,7 +21,7 @@ namespace OCA\Mail\Service\AutoConfig;
 
 use OCA\Mail\Service\Logger;
 
-class MozillaIspDb {
+class IspDb {
 
 	private $logger;
 	private $urls = array(
@@ -76,7 +76,7 @@ class MozillaIspDb {
 	 * @return array
 	 */
 	public function query($domain, $tryMx = true) {
-		$this->logger->debug("MozillaIsbDb: querying <$domain>");
+		$this->logger->debug("IsbDb: querying <$domain>");
 		if (strpos($domain, '@') !== false) {
 			// TODO: use horde mail address parsing instead
 			list(, $domain) = explode('@', $domain);
@@ -85,7 +85,7 @@ class MozillaIspDb {
 		$provider = [];
 		foreach ($this->urls as $url) {
 			$url = str_replace("{DOMAIN}", $domain, $url);
-			$this->logger->debug("MozillaIsbDb: querying <$domain> via <$url>");
+			$this->logger->debug("IsbDb: querying <$domain> via <$url>");
 
 			$provider = $this->queryUrl($url);
 			if (!empty($provider)) {

--- a/tests/service/autoconfig/ispdbtest.php
+++ b/tests/service/autoconfig/ispdbtest.php
@@ -21,12 +21,12 @@
 
 namespace OCA\Mail\Tests\Service\Autoconfig;
 
-use OCA\Mail\Service\AutoConfig\MozillaIspDb;
+use OCA\Mail\Service\AutoConfig\IspDb;
 use PHPUnit_Framework_TestCase;
 
-class MozillaIspDbtest extends PHPUnit_Framework_TestCase {
+class IspDbtest extends PHPUnit_Framework_TestCase {
 
-	private $mozillaIspDb;
+	private $ispDb;
 
 	protected function setUp() {
 		parent::setUp();
@@ -34,7 +34,7 @@ class MozillaIspDbtest extends PHPUnit_Framework_TestCase {
 		$logger = $this->getMockBuilder('\OCA\Mail\Service\Logger')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->mozillaIspDb = new MozillaIspDb($logger);
+		$this->ispDb = new IspDb($logger);
 	}
 
 	public function queryData() {
@@ -51,7 +51,7 @@ class MozillaIspDbtest extends PHPUnit_Framework_TestCase {
 	 * @param string $domain
 	 */
 	public function testQueryGmail($domain) {
-		$result = $this->mozillaIspDb->query($domain);
+		$result = $this->ispDb->query($domain);
 
 		$this->assertContainsIspData($result);
 	}


### PR DESCRIPTION
Before this PR we only query `https://autoconfig.thunderbird.net/v1.1/{DOMAIN}`. A lot of small providers are not in this source.

This PR adds provider specific source(s): `https://autoconfig.{DOMAIN}/mail/config-v1.1.xml`, ...

Related:
 - https://github.com/owncloud/mail/issues/678
 - https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration
