### PR TITLE
Move startup logic to App::onStart

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -11,22 +11,104 @@
 define(function(require) {
 	'use strict';
 
+	var $ = require('jquery');
 	var Marionette = require('marionette');
 	var AppView = require('views/app');
+	var AccountController = require('controller/accountcontroller');
+	var FolderController = require('./controller/foldercontroller');
 	var Radio = require('radio');
 
 	// Load controllers/services
-	require('controller/accountcontroller');
 	require('controller/foldercontroller');
 	require('controller/messagecontroller');
 	require('service/accountservice');
 	require('service/folderservice');
 	require('notification');
 
-	var Mail = new Marionette.Application();
+	var Mail = Marionette.Application.extend({
+		initialize: function() {
+			this.listenTo(Radio.account, 'add', this.addAccount);
+		},
+		/**
+		 * Handle mailto links
+		 *
+		 * @returns {boolean} whether the composer has been shown
+		 */
+		handleMailto: function() {
+			var hash = window.location.hash;
+			if (hash === '' || hash === '#') {
+				// Nothing to do
+				return false;
+			}
+
+			// Remove leading #
+			hash = hash.substr(1);
+
+			var composerOptions = {};
+			var params = hash.split('&');
+
+			_.each(params, function(param) {
+				param = param.split('=');
+				var key = param[0];
+				var value = param[1];
+				value = decodeURIComponent((value).replace(/\+/g, '%20'));
+
+				switch (key) {
+					case 'mailto':
+					case 'to':
+						composerOptions.to = value;
+						break;
+					case 'cc':
+						composerOptions.cc = value;
+						break;
+					case 'bcc':
+						composerOptions.bcc = value;
+						break;
+					case 'subject':
+						composerOptions.subject = value;
+						break;
+					case 'body':
+						composerOptions.body = value;
+						break;
+				}
+			});
+
+			window.location.hash = '';
+			Radio.ui.trigger('composer:show', composerOptions);
+			return true;
+		},
+		addAccount: function() {
+			Radio.ui.trigger('composer:leave');
+			Radio.ui.trigger('navigation:hide');
+			Radio.ui.trigger('setup:show');
+		}
+	});
+
+	Mail = new Mail();
 
 	Mail.on('start', function() {
-		Radio.account.trigger('load');
+		Radio.ui.trigger('content:loading');
+
+		var loadingAccounts = AccountController.loadAccounts();
+		var _this = this;
+		$.when(loadingAccounts).done(function(accounts) {
+			$('#app-navigation').removeClass('icon-loading');
+
+			if (accounts.isEmpty()) {
+				_this.addAccount();
+			} else {
+				if (!_this.handleMailto()) {
+					Radio.ui.trigger('messagecontent:show');
+				}
+
+				var firstAccount = accounts.at(0);
+				var firstFolder = firstAccount.get('folders').at(0);
+				FolderController.showFolder(firstAccount, firstFolder);
+			}
+
+			// Start fetching messages in background
+			require('background').messageFetcher.start();
+		});
 	});
 
 	Mail.view = new AppView();

--- a/js/ui.js
+++ b/js/ui.js
@@ -11,103 +11,13 @@
 define(function(require) {
 	'use strict';
 
-	var _ = require('underscore');
 	var $ = require('jquery');
 	var OC = require('OC');
 	var Radio = require('radio');
 
 	require('views/helper');
 
-	Radio.ui.on('folder:show', loadFolder);
-
 	var composerVisible = false;
-
-	/**
-	 * @param {Account} account
-	 * @param {Folder} folder
-	 * @param {boolean} noSelect
-	 * @returns {undefined}
-	 */
-	function loadFolder(account, folder, noSelect) {
-		Radio.ui.trigger('composer:leave');
-
-		if (require('state').messagesLoading !== null) {
-			require('state').messagesLoading.abort();
-		}
-		if (require('state').messageLoading !== null) {
-			require('state').messageLoading.abort();
-		}
-
-		// Set folder active
-		Radio.folder.trigger('setactive', account, folder);
-		Radio.ui.trigger('content:loading');
-		Radio.ui.trigger('messagesview:messages:reset');
-
-		$('#load-new-mail-messages').hide();
-		$('#load-more-mail-messages').hide();
-
-		if (noSelect) {
-			$('#emptycontent').show();
-			require('state').currentAccount = account;
-			require('state').currentFolder = folder;
-			Radio.ui.trigger('messagesview:message:setactive', null);
-			require('state').currentlyLoading = null;
-		} else {
-			require('communication').fetchMessageList(account, folder, {
-				onSuccess: function(messages, cached) {
-					Radio.ui.trigger('messagecontent:show');
-					require('state').currentlyLoading = null;
-					require('state').currentAccount = account;
-					require('state').currentFolder = folder;
-					Radio.ui.trigger('messagesview:message:setactive', null);
-
-					// Fade out the message composer
-					$('#mail_new_message').prop('disabled', false);
-
-					if (messages.length > 0) {
-						Radio.ui.trigger('messagesview:messages:add', messages);
-
-						// Fetch first 10 messages in background
-						_.each(messages.slice(0, 10), function(
-							message) {
-							require('background').messageFetcher.push(message.id);
-						});
-
-						var messageId = messages[0].id;
-						Radio.message.trigger('load', account, folder, messageId);
-						// Show 'Load More' button if there are
-						// more messages than the pagination limit
-						if (messages.length > 20) {
-							$('#load-more-mail-messages')
-								.fadeIn()
-								.css('display', 'block');
-						}
-					} else {
-						$('#emptycontent').show();
-					}
-					$('#load-new-mail-messages')
-						.fadeIn()
-						.css('display', 'block')
-						.prop('disabled', false);
-
-					if (cached) {
-						// Trigger folder update
-						// TODO: replace with horde sync once it's implemented
-						Radio.ui.trigger('messagesview:messages:update');
-					}
-				},
-				onError: function(error, textStatus) {
-					if (textStatus !== 'abort') {
-						// Set the old folder as being active
-						var folder = require('state').currentFolder;
-						Radio.folder.trigger('setactive', account, folder);
-						Radio.ui.trigger('error:show', t('mail', 'Error while loading messages.'));
-					}
-				},
-				cache: true
-			});
-		}
-	}
 
 	/**
 	 * @param {number} messageId


### PR DESCRIPTION
This PR moves some code to better fitting places. Moving the start-up logic out of classes it doesn't really fit will make the introduction of the Backbone router easier as we now have all in one place.

I couldn't find any new errors, @Gomez @jancborchardt test this please