### PR TITLE
Prevent the browser from navigating on cc/bcc click

### DIFF
--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -218,7 +218,8 @@ define(function(require) {
 			}
 			return true;
 		},
-		ccBccToggle: function() {
+		ccBccToggle: function(e) {
+			e.preventDefault();
 			this.$('.composer-cc-bcc').slideToggle();
 			this.$('.composer-cc-bcc .cc').focus();
 			this.$('.composer-cc-bcc-toggle').fadeOut();


### PR DESCRIPTION
fixes #1440

This was caused by the new app router, it reacted to the url change and navigated away.

@jancborchardt @tahaalibra @skjnldsv @irgendwie super easy to review :D