### PR TITLE
Make Logger independent of ILogger

### DIFF
--- a/lib/controller/accountscontroller.php
+++ b/lib/controller/accountscontroller.php
@@ -45,7 +45,6 @@ use OCP\AppFramework\Http\Response;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
 
@@ -63,7 +62,7 @@ class AccountsController extends Controller {
 	/** @var Folder */
 	private $userFolder;
 
-	/** @var ILogger */
+	/** @var Logger */
 	private $logger;
 
 	/** @var IL10N */
@@ -233,7 +232,7 @@ class AccountsController extends Controller {
 					['data' => ['id' => $newAccount->getId()]],
 					Http::STATUS_CREATED);
 			}
-		} catch (\Exception $ex) {
+		} catch (Exception $ex) {
 			$this->logger->error('Creating account failed: ' . $ex->getMessage());
 			return new JSONResponse(
 				array('message' => $this->l10n->t('Creating account failed: ') . $ex->getMessage()),

--- a/lib/service/logger.php
+++ b/lib/service/logger.php
@@ -24,7 +24,7 @@ namespace OCA\Mail\Service;
 
 use OCP\ILogger;
 
-class Logger implements ILogger {
+class Logger {
 
 	/** @var array */
 	private $context;
@@ -103,14 +103,14 @@ class Logger implements ILogger {
 	/**
 	 * @inheritdoc
 	 */
-	public function log($level, $message, array $context = array()) {
+	public function log($level, $message, array $context = []) {
 		$this->logger->log($level, $message, array_merge($this->context, $context));
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function logException(\Exception $exception, array $context = array()) {
+	public function logException($exception, array $context = []) {
 		$this->logger->logException($exception, array_merge($this->context, $context));
 	}
 


### PR DESCRIPTION
As this interface has now changed the second time, I changed our Logger to not explicitly implement that interface anymore. In fact, it's even impossible to implement because in 8.2 the method signature has the Exception typehint, which has been removed in 9.1 and PHP does not allow method overloads.

@DeepDiver1975 should this be considered when interfaces in core are changed?

@Gomez @Scheirle