### PR TITLE
Show attachments as blocks instead of list to allow enhanced actions

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -617,10 +617,14 @@ input.submit-message,
 .mail-message-attachments .attachments > div {
 	position: relative;
 	display: inline-block;
-	/*width: calc(50% - 8px);*/
 	border: 1px solid #f5f5f5;
 	margin: 5px;
 	padding: 6px;
+}
+.mail-message-attachments .attachments > div:hover,
+.mail-message-attachments .attachments > div span:hover {
+	background-color: #f8f8f8;
+	cursor: pointer;
 }
 @media only screen and (max-width: 768px) {
 	.mail-message-attachments .attachments > div {

--- a/css/mail.css
+++ b/css/mail.css
@@ -617,14 +617,29 @@ input.submit-message,
 .mail-message-attachments .attachments > div {
 	position: relative;
 	display: inline-block;
-	width: calc(25% - 12px);
+	/*width: calc(50% - 8px);*/
 	border: 1px solid #f5f5f5;
 	margin: 5px;
 	padding: 6px;
 }
+@media only screen and (max-width: 768px) {
+	.mail-message-attachments .attachments > div {
+		width: calc(100% - 5px);
+	}
+}
+@media only screen and (min-width: 769px) and (max-width: 1400px) {
+	.mail-message-attachments .attachments > div {
+		width: calc(50% - 10px);
+	}
+}
+@media only screen and (min-width: 1401px) {
+	.mail-message-attachments .attachments > div {
+		width: calc(33% - 12px);
+	}
+}
 .mail-message-attachments .mail-attached-image {
 	max-width: 100%;
-	max-height: 100px;
+	max-height: 120px;
 }
 .attachment-save-to-cloud,
 .attachment-download {

--- a/css/mail.css
+++ b/css/mail.css
@@ -614,20 +614,30 @@ input.submit-message,
 .mail-message-attachments {
 	margin-bottom: 20px;
 }
-.mail-message-attachment {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+.mail-message-attachments .attachments > div {
+	position: relative;
+	display: inline-block;
+	width: calc(25% - 12px);
+	border: 1px solid #f5f5f5;
+	margin: 5px;
+	padding: 6px;
 }
-.mail-message-attachment-image {
-	margin-bottom: 32px;
+.mail-message-attachments .mail-attached-image {
+	max-width: 100%;
+	max-height: 100px;
 }
 .attachment-save-to-cloud,
 .attachment-download {
+	position: absolute;
 	height: 32px;
-	min-width: 32px;
-	float: left;
-	display: inline-block;
+	width: 32px;
+	bottom: 3px;
+}
+.attachment-save-to-cloud {
+	right: 3px;
+}
+.attachment-download {
+	right: 41px;
 }
 /* show icon + text for Download all button
 	as well as when there is only one attachment */
@@ -637,6 +647,14 @@ input.submit-message,
 .mail-message-attachment-single .attachment-download {
 	background-position: 9px center;
 	padding-left: 32px;
+}
+.attachment-name {
+	display: inline-block;
+	width: calc(100% - 110px);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	vertical-align: middle;
 }
 /* show attachment size less prominent */
 .attachment-size {

--- a/js/app.js
+++ b/js/app.js
@@ -37,6 +37,7 @@ define(function(require) {
 	require('controller/foldercontroller');
 	require('controller/messagecontroller');
 	require('service/accountservice');
+	require('service/attachmentservice');
 	require('service/folderservice');
 	require('service/messageservice');
 	require('notification');

--- a/js/models/attachment.js
+++ b/js/models/attachment.js
@@ -5,20 +5,23 @@
  * later. See the COPYING file.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @copyright Christoph Wurst 2015
+ * @copyright Christoph Wurst 2015, 2016
  */
 
 define(function(require) {
 	'use strict';
 
 	var Backbone = require('backbone');
+	var _ = require('underscore');
 
 	/**
 	 * @class Attachment
 	 */
 	var Attachment = Backbone.Model.extend({
 		initialize: function() {
-			this.set('id', _.uniqueId());
+			if (_.isUndefined(this.get('id'))) {
+				this.set('id', _.uniqueId());
+			}
 
 			var s = this.get('fileName');
 			if (s.charAt(0) === '/') {

--- a/js/service/attachmentservice.js
+++ b/js/service/attachmentservice.js
@@ -1,0 +1,66 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var $ = require('jquery');
+	var OC = require('OC');
+	var Radio = require('radio');
+
+	Radio.message.reply('save:cloud', saveToFiles);
+
+	/**
+	 * @param {Account} account
+	 * @param {Folder} folder
+	 * @param {number} messageId
+	 * @param {number} attachmentId
+	 * @param {string} path
+	 * @returns {Promise}
+	 */
+	function saveToFiles(account, folder, messageId, attachmentId, path) {
+		var defer = $.Deferred();
+		var url = OC.generateUrl(
+			'apps/mail/accounts/{accountId}/' +
+			'folders/{folderId}/messages/{messageId}/' +
+			'attachment/{attachmentId}', {
+				accountId: account.get('accountId'),
+				folderId: folder.get('id'),
+				messageId: messageId,
+				attachmentId: attachmentId
+			});
+
+		var options = {
+			data: {
+				targetPath: path
+			},
+			type: 'POST',
+			success: function() {
+				defer.resolve();
+			},
+			error: function() {
+				defer.reject();
+			}
+		};
+
+		$.ajax(url, options);
+		return defer.promise();
+	}
+
+});

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -1,0 +1,8 @@
+{{#if isImage}}
+<img class="mail-attached-image" src="{{downloadUrl}}">
+<br>
+{{/if}}
+<img class="attachment-icon" src="{{mimeUrl}}" />
+<span class="attachment-name">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
+<a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
+<button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -3,6 +3,6 @@
 <br>
 {{/if}}
 <img class="attachment-icon" src="{{mimeUrl}}" />
-<span class="attachment-name">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
+<span class="attachment-name" title="{{fileName}} ({{humanFileSize size}})">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
 <a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
 <button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -4,5 +4,5 @@
 {{/if}}
 <img class="attachment-icon" src="{{mimeUrl}}" />
 <span class="attachment-name" title="{{fileName}} ({{humanFileSize size}})">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
-<a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
+<button class="button icon-download attachment-download" title="{{ t 'Download attachment' }}"></button>
 <button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>

--- a/js/templates/message-attachments.html
+++ b/js/templates/message-attachments.html
@@ -3,6 +3,6 @@
 </div>
 {{#if moreThanOne}}
 <p>
-	<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
+	<button class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
 </p>
 {{/if}}

--- a/js/templates/message-attachments.html
+++ b/js/templates/message-attachments.html
@@ -1,40 +1,8 @@
 <div class="attachments">
 	
 </div>
+{{#if moreThanOne}}
 <p>
 	<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
 </p>
-
-<!-- {{#if attachment}}
-<ul>
-	<li class="mail-message-attachment mail-message-attachment-single" data-message-id="{{attachment.messageId}}" data-attachment-id="{{attachment.id}}" data-attachment-mime="{{attachment.mime}}">
-		{{#if attachment.isImage}}
-		<img class="mail-attached-image" src="{{attachment.downloadUrl}}">
-		<br>
-		{{/if}}
-		<img class="attachment-icon" src="{{attachment.mimeUrl}}" />
-		{{attachment.fileName}} <span class="attachment-size">({{humanFileSize attachment.size}})</span><br/>
-		<a class="button icon-download attachment-download" href="{{attachment.downloadUrl}}">{{ t 'Download attachment' }}</a>
-		<button class="icon-folder attachment-save-to-cloud">{{ t 'Save to Files' }}</button>
-	</li>
-</ul>
 {{/if}}
-{{#if attachments}}
-<ul>
-	{{#each attachments}}
-	<li class="mail-message-attachment {{#if isImage}}mail-message-attachment-image{{/if}}" data-message-id="{{messageId}}" data-attachment-id="{{id}}" data-attachment-mime="{{mime}}">
-		{{#if isImage}}
-		<img class="mail-attached-image" src="{{downloadUrl}}">
-		<br>
-		{{/if}}
-		<a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
-		<button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>
-		<img class="attachment-icon" src="{{mimeUrl}}" />
-		{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span>
-	</li>
-	{{/each}}
-</ul>
-<p>
-	<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
-</p>
-{{/if}} -->

--- a/js/templates/message-attachments.html
+++ b/js/templates/message-attachments.html
@@ -1,0 +1,40 @@
+<div class="attachments">
+	
+</div>
+<p>
+	<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
+</p>
+
+<!-- {{#if attachment}}
+<ul>
+	<li class="mail-message-attachment mail-message-attachment-single" data-message-id="{{attachment.messageId}}" data-attachment-id="{{attachment.id}}" data-attachment-mime="{{attachment.mime}}">
+		{{#if attachment.isImage}}
+		<img class="mail-attached-image" src="{{attachment.downloadUrl}}">
+		<br>
+		{{/if}}
+		<img class="attachment-icon" src="{{attachment.mimeUrl}}" />
+		{{attachment.fileName}} <span class="attachment-size">({{humanFileSize attachment.size}})</span><br/>
+		<a class="button icon-download attachment-download" href="{{attachment.downloadUrl}}">{{ t 'Download attachment' }}</a>
+		<button class="icon-folder attachment-save-to-cloud">{{ t 'Save to Files' }}</button>
+	</li>
+</ul>
+{{/if}}
+{{#if attachments}}
+<ul>
+	{{#each attachments}}
+	<li class="mail-message-attachment {{#if isImage}}mail-message-attachment-image{{/if}}" data-message-id="{{messageId}}" data-attachment-id="{{id}}" data-attachment-mime="{{mime}}">
+		{{#if isImage}}
+		<img class="mail-attached-image" src="{{downloadUrl}}">
+		<br>
+		{{/if}}
+		<a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
+		<button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>
+		<img class="attachment-icon" src="{{mimeUrl}}" />
+		{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span>
+	</li>
+	{{/each}}
+</ul>
+<p>
+	<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
+</p>
+{{/if}} -->

--- a/js/templates/message.html
+++ b/js/templates/message.html
@@ -33,41 +33,7 @@
 	</div>
 	{{/if}}
 
-	<div class="mail-message-attachments">
-		{{#if attachment}}
-		<ul>
-			<li class="mail-message-attachment mail-message-attachment-single" data-message-id="{{attachment.messageId}}" data-attachment-id="{{attachment.id}}" data-attachment-mime="{{attachment.mime}}">
-				{{#if attachment.isImage}}
-					<img class="mail-attached-image" src="{{attachment.downloadUrl}}">
-					<br>
-				{{/if}}
-				<img class="attachment-icon" src="{{attachment.mimeUrl}}" />
-				{{attachment.fileName}} <span class="attachment-size">({{humanFileSize attachment.size}})</span><br/>
-				<a class="button icon-download attachment-download" href="{{attachment.downloadUrl}}">{{ t 'Download attachment' }}</a>
-				<button class="icon-folder attachment-save-to-cloud">{{ t 'Save to Files' }}</button>
-			</li>
-		</ul>
-		{{/if}}
-		{{#if attachments}}
-		<ul>
-			{{#each attachments}}
-			<li class="mail-message-attachment {{#if isImage}}mail-message-attachment-image{{/if}}" data-message-id="{{messageId}}" data-attachment-id="{{id}}" data-attachment-mime="{{mime}}">
-				{{#if isImage}}
-					<img class="mail-attached-image" src="{{downloadUrl}}">
-					<br>
-				{{/if}}
-				<a class="button icon-download attachment-download" href="{{downloadUrl}}" title="{{ t 'Download attachment' }}"></a>
-				<button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>
-				<img class="attachment-icon" src="{{mimeUrl}}" />
-				{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span>
-			</li>
-			{{/each}}
-		</ul>
-		<p>
-			<button data-message-id="{{id}}" class="icon-folder attachments-save-to-cloud">{{ t 'Save all to Files' }}</button>
-		</p>
-		{{/if}}
-	</div>
+	<div class="mail-message-attachments"></div>
 	<div id="reply-composer"></div>
 	<input type="button" id="forward-button" value="{{ t 'Forward' }}">
 </div>

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -149,11 +149,6 @@ define(function(require) {
 			// Resize iframe
 			var iframe = $('#mail-content iframe');
 			iframe.height(iframe.contents().find('html').height() + 20);
-
-			// resize width of attached images
-			$('.mail-message-attachments .mail-attached-image').each(function() {
-				$(this).css('max-width', $('.mail-message-body').width());
-			});
 		},
 		render: function() {
 			// This view doesn't need rendering

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -67,21 +67,6 @@ define(function(require) {
 				Radio.message.trigger('forward');
 			});
 
-			// TODO: create marionette view and encapsulate events
-			$(document).on('click', '#mail-message .attachment-save-to-cloud', function(event) {
-				event.stopPropagation();
-				var messageId = $(this).parent().data('messageId');
-				var attachmentId = $(this).parent().data('attachmentId');
-				Radio.message.trigger('attachment:save', messageId, attachmentId);
-			});
-
-			// TODO: create marionette view and encapsulate events
-			$(document).on('click', '#mail-message .attachments-save-to-cloud', function(event) {
-				event.stopPropagation();
-				var messageId = $(this).data('messageId');
-				Radio.message.trigger('attachment:save', messageId);
-			});
-
 			$(document).on('click', '.link-mailto', function(event) {
 				Radio.ui.trigger('composer:show', event);
 			});

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -135,7 +135,8 @@ define(function(require) {
 			var folderId = this.message.get('folderId');
 
 			this.attachments.show(new MessageAttachmentsView({
-				collection: new Attachments(this.message.get('attachments'))
+				collection: new Attachments(this.message.get('attachments')),
+				message: this.model
 			}));
 
 			// setup reply composer view

--- a/js/views/message.js
+++ b/js/views/message.js
@@ -17,8 +17,10 @@ define(function(require) {
 	var Handlebars = require('handlebars');
 	var _ = require('underscore');
 	var $ = require('jquery');
+	var Attachments = require('models/attachments');
 	var HtmlHelper = require('util/htmlhelper');
 	var ComposerView = require('views/composer');
+	var MessageAttachmentsView = require('views/messageattachments');
 	var MessageTemplate = require('text!templates/message.html');
 
 	return Marionette.LayoutView.extend({
@@ -30,7 +32,8 @@ define(function(require) {
 			messageIframe: 'iframe'
 		},
 		regions: {
-			replyComposer: '#reply-composer'
+			replyComposer: '#reply-composer',
+			attachments: '.mail-message-attachments'
 		},
 		initialize: function(options) {
 			this.message = options.model;
@@ -127,18 +130,13 @@ define(function(require) {
 		onShow: function() {
 			this.ui.messageIframe.on('load', _.bind(this.onIframeLoad, this));
 
-			// Set max width for attached images
-			var _this = this;
-			this.$('.mail-message-attachments img.mail-attached-image').each(function() {
-				$(this).css({
-					'max-width': _this.$('.mail-message-body').width(),
-					'height': 'auto'
-				});
-			});
-
 			// TODO: add folder/account reference to message
 			var account = require('state').accounts.get(this.message.get('accountId'));
 			var folderId = this.message.get('folderId');
+
+			this.attachments.show(new MessageAttachmentsView({
+				collection: new Attachments(this.message.get('attachments'))
+			}));
 
 			// setup reply composer view
 			this.replyComposer.show(new ComposerView({

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -20,15 +20,54 @@
 define(function(require) {
 	'use strict';
 
+	var $ = require('jquery');
 	var Handlebars = require('handlebars');
 	var Marionette = require('marionette');
+	var MessageController = require('controller/messagecontroller');
 	var MessageAttachmentTemplate = require('text!templates/message-attachment.html');
 
 	/**
 	 * @class MessageAttachmentView
 	 */
 	var MessageAttachmentView = Marionette.ItemView.extend({
-		template: Handlebars.compile(MessageAttachmentTemplate)
+		template: Handlebars.compile(MessageAttachmentTemplate),
+		ui: {
+			'downloadButton': '.attachment-download',
+			'saveToCloudButton': '.attachment-save-to-cloud'
+		},
+		events: {
+			'click': '_onDownload',
+			'click @ui.saveToCloudButton': '_onSaveToCloud'
+		},
+		_onDownload: function(e) {
+			if (!e.isDefaultPrevented()) {
+				e.preventDefault();
+				window.location = this.model.get('downloadUrl');
+			}
+		},
+		_onSaveToCloud: function(e) {
+			e.preventDefault();
+			// TODO: 'message' should be a property of this attachment model
+			// TODO: 'folder' should be a property of the message model and so on
+			var account = require('state').currentAccount;
+			var folder = require('state').currentFolder;
+			var messageId = this.model.get('messageId');
+			var attachmentId = this.model.get('id');
+			var saving = MessageController.saveAttachmentToFiles(account, folder, messageId, attachmentId);
+
+			// Loading feedback
+			this.ui.saveToCloudButton.removeClass('icon-folder')
+				.addClass('icon-loading-small')
+				.prop('disabled', true);
+
+			var _this = this;
+			$.when(saving).always(function() {
+				// Remove loading feedback again
+				_this.ui.saveToCloudButton.addClass('icon-folder')
+					.removeClass('icon-loading-small')
+					.prop('disabled', false);
+			});
+		}
 	});
 
 	return MessageAttachmentView;

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -1,0 +1,35 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Handlebars = require('handlebars');
+	var Marionette = require('marionette');
+	var MessageAttachmentTemplate = require('text!templates/message-attachment.html');
+
+	/**
+	 * @class MessageAttachmentView
+	 */
+	var MessageAttachmentView = Marionette.ItemView.extend({
+		template: Handlebars.compile(MessageAttachmentTemplate)
+	});
+
+	return MessageAttachmentView;
+});

--- a/js/views/messageattachments.js
+++ b/js/views/messageattachments.js
@@ -1,0 +1,41 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Handlebars = require('handlebars');
+	var Marionette = require('marionette');
+	var AttachmentView = require('views/messageattachment');
+	var AttachmentsTemplate = require('text!templates/message-attachments.html');
+
+	/**
+	 * @type MessageAttachmentsView
+	 */
+	var MessageAttachmentsView = Marionette.CompositeView.extend({
+		/**
+		 * @lends Marionette.CompositeView
+		 */
+		template: Handlebars.compile(AttachmentsTemplate),
+		childView: AttachmentView,
+		childViewContainer: '.attachments'
+	});
+
+	return MessageAttachmentsView;
+});

--- a/js/views/messageattachments.js
+++ b/js/views/messageattachments.js
@@ -33,6 +33,11 @@ define(function(require) {
 		 * @lends Marionette.CompositeView
 		 */
 		template: Handlebars.compile(AttachmentsTemplate),
+		templateHelpers: function() {
+			return {
+				moreThanOne: this.collection.length > 1
+			};
+		},
 		childView: AttachmentView,
 		childViewContainer: '.attachments'
 	});

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -272,7 +272,7 @@ class MessagesController extends Controller {
 	 * @param int $accountId
 	 * @param string $folderId
 	 * @param string $messageId
-	 * @param string $attachmentId
+	 * @param int $attachmentId
 	 * @param string $targetPath
 	 * @return JSONResponse
 	 */

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -459,9 +459,6 @@ class MessagesController extends Controller {
 			$json['htmlBodyUrl'] = $this->buildHtmlBodyUrl($accountId, $folderId, $id);
 		}
 
-		if (isset($json['attachment'])) {
-			$json['attachment'] = $this->enrichDownloadUrl($accountId, $folderId, $id, $json['attachment']);
-		}
 		if (isset($json['attachments'])) {
 			$json['attachments'] = array_map(function ($a) use ($accountId, $folderId, $id) {
 				return $this->enrichDownloadUrl($accountId, $folderId, $id, $a);

--- a/lib/model/imapmessage.php
+++ b/lib/model/imapmessage.php
@@ -486,12 +486,7 @@ class IMAPMessage implements IMessage {
 			$data['signature'] = $signature;
 		}
 
-		if (count($this->attachments) === 1) {
-			$data['attachment'] = $this->attachments[0];
-		}
-		if (count($this->attachments) > 1) {
-			$data['attachments'] = $this->attachments;
-		}
+		$data['attachments'] = $this->attachments;
 
 		if ($specialRole === 'sent') {
 			$data['replyToList'] = $this->getToList(true);


### PR DESCRIPTION
This moves attachment rendering out of the message view and shows attachment as blocks instead of a simple list:
![bildschirmfoto von 2016-04-24 15-48-31](https://cloud.githubusercontent.com/assets/1374172/14767969/f00e43f2-0a33-11e6-9622-74a01398a841.png)


My goal is to make the attachments view ready for enhanced attachment actions, like integration with other apps (contacts, calendar, maps) and previews of other file types (ref #1374, #79).

TODO:
- [x] fix single attachment
- [x] make attachment width responsive (on mobile there should be only a single attachment per line)
- [x] rebase onto #1447 once it's merged so the save-attachment-methods can be moved into the attachment(s) view
- [x] show attachments with previews first? cc @jancborchardt (is done [by the server](https://github.com/owncloud/mail/blob/master/lib/controller/messagescontroller.php#L470-L479) already)
- [x] show full attachment name on hover
- [x] open attachment on click (ref #1308)
- [x] fix 'save to cloud' urls (fixes #1437)
- [x] find out while core failes saving the files – it failed only on my dev instance apparently

Ideas for future PRs:
- use popover for download and other attachment actions

fixes #1308