### PR TITLE
Resolve accounts loading promise in all cases

### DIFF
--- a/js/controller/accountcontroller.js
+++ b/js/controller/accountcontroller.js
@@ -35,7 +35,8 @@ define(function(require) {
 
 		$.when(fetchingAccounts).done(function(accounts) {
 			if (accounts.length === 0) {
-				addAccount();
+				defer.resolve(accounts);
+				Radio.navigation.trigger('setup');
 			} else {
 				var loadingAccounts = accounts.map(function(account) {
 					return FolderController.loadFolder(account);


### PR DESCRIPTION
fixes #1458

My bad, I forgot to resolve the promise when no accounts are configured, which led to the backbone router not being started. Small bug with great impact.

@Gomez @jancborchardt @irgendwie @DeepDiver1975

@Scheirle @kajla please check if that fixes the reported issue for you

Note to myself: Test releases before releasing…