### PR TITLE
Navigate to newly created account after successful setup; responsive …

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -24,6 +24,21 @@
 	margin: 0 auto;
 	padding-top: 30px;
 }
+@media only screen and (max-height: 400px) {
+	#setup #emptycontent {
+		margin-top: 0px;
+	}
+}
+@media only screen and (min-height: 401px) and (max-height: 600px) {
+	#setup #emptycontent {
+		margin-top: 2vh;
+	}
+}
+@media only screen and (min-height: 601px) {
+	#setup #emptycontent {
+		margin-top: 10vh;
+	}
+}
 #setup h2 {
 	text-align: center;
 	position: relative;

--- a/js/views/setup.js
+++ b/js/views/setup.js
@@ -15,6 +15,7 @@ define(function(require) {
 	var _ = require('underscore');
 	var Marionette = require('marionette');
 	var Handlebars = require('handlebars');
+	var AccountController = require('controller/accountcontroller');
 	var Radio = require('radio');
 	var SetupTemplate = require('text!templates/setup.html');
 
@@ -147,7 +148,15 @@ define(function(require) {
 			$.when(creatingAccount).done(function() {
 				Radio.ui.trigger('navigation:show');
 				// reload accounts
-				Radio.account.trigger('load');
+				$.when(AccountController.loadAccounts()).done(function(accounts) {
+					$('#app-navigation').removeClass('icon-loading');
+
+					// Let's assume there's at least one account after a successful
+					// setup, so let's show the first one (could be the unified inbox)
+					var firstAccount = accounts.first();
+					var firstFolder = accounts.first();
+					Radio.navigation.trigger('folder', firstAccount.get('accountId'), firstFolder.get('id'));
+				});
 			});
 
 			$.when(creatingAccount).fail(function(error) {


### PR DESCRIPTION
…setup view
fixes #1460 and makes the setup view a little bit more repsonsive to different screen sizes:

![bildschirmfoto von 2016-04-28 20-21-52](https://cloud.githubusercontent.com/assets/1374172/14896676/15f5583c-0d7f-11e6-990b-c0c8f5c0a54f.png)
![bildschirmfoto von 2016-04-28 20-21-59](https://cloud.githubusercontent.com/assets/1374172/14896678/1627d3f2-0d7f-11e6-814d-fcd40b333702.png)
![bildschirmfoto von 2016-04-28 20-22-08](https://cloud.githubusercontent.com/assets/1374172/14896677/1625fb04-0d7f-11e6-8479-78186f966847.png)


@Scheirle please test if this fixes the issue you reported, thanks!

@Gomez @jancborchardt @tahaalibra @Tagada85 @enoch85 