### PR TITLE
remove unused require shims from tests

### DIFF
--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -24,14 +24,6 @@ require.config({
 		OC: 'tests/mocks/OC',
 		text: 'vendor/text/text'
 	},
-	shim: {
-		handlebars: {
-			exports: 'Handlebars'
-		},
-		jquery: {
-			exports: '$'
-		}
-	},
 	// dynamically load all test files
 	deps: allTestFiles,
 	// we have to kickoff jasmine, as it is asynchronous


### PR DESCRIPTION
Following #1465, also removing left-over shims of requirejs from the tests.
