### PR TITLE
show first folder of an account incase of invalid folder id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   [#1483](https://github.com/owncloud/mail/pull/1483) @ChristophWurst
 - Don't send messages in flowed text format
   [#1482](https://github.com/owncloud/mail/pull/1482) @ChristophWurst
+- Show first folder of an account incase of invalid folder id
+  [#1471] (https://github.com/owncloud/mail/pull/1471) @tahaalibra
 
 ## 0.4.4 – 2016-05-06
 

--- a/js/routecontroller.js
+++ b/js/routecontroller.js
@@ -108,9 +108,8 @@ define(function(require) {
 
 			var folder = account.get('folders').get(folderId);
 			if (_.isUndefined(folder)) {
-				// TODO: show first folder of this account
-				_this.default();
-				return;
+				folder = account.get('folders').at(0);
+				this._navigate('accounts/' + accountId + '/folders/' + folder.get('id'));
 			}
 			FolderController.showFolder(account, folder, noSelect);
 		},


### PR DESCRIPTION
if the folder id is not found then the user will be sent to the first folder of that account

please review @ChristophWurst 