### PR TITLE
add ability to import ics attachments into the calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## 0.4.5 – UNRELEASED
 
+### Added
+- Ability to import ics attachments into the calendar
+  [#1473](https://github.com/owncloud/mail/pull/1473) @ChristophWurst
+
 ### Fixed
 - Bring back menu toggle button for mobile
   [#1483](https://github.com/owncloud/mail/pull/1483) @ChristophWurst

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Why is this so awesome?
 
-* :rocket: **Integration with other ownCloud apps!** Currently Contacts & Files – more to come.
+* :rocket: **Integration with other ownCloud apps!** Currently Contacts, Calendar & Files – more to come.
 * :inbox_tray: **Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox.
 * :lock: **Send & receive encrypted emails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.
 * :see_no_evil: **We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
@@ -23,7 +23,6 @@ And in the works for the [coming versions](https://github.com/owncloud/mail/mile
 * :books: [Proper grouping of message threads](https://github.com/owncloud/mail/issues/21) 
 * :zap: [Caching to make everything faster](https://github.com/owncloud/mail/issues/480)
 * :paperclip: [Even better attachment support](https://github.com/owncloud/mail/issues/462) 
-* :date: [Calendar integration](https://github.com/owncloud/mail/issues/79) 
 * :package: [Folder management & moving mails](https://github.com/owncloud/mail/issues/411) 
 
 ## Installation

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,8 @@
     "jquery-visibility": "~1.0.11",
     "requirejs": "2.2.0",
     "text": "^2.0.14",
-    "underscore": "~1.8.3"
+    "underscore": "~1.8.3",
+    "davclient.js": "git@github.com:evert/davclient.js.git",
+    "es6-promise": "^3.2.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "text": "^2.0.14",
     "underscore": "~1.8.3",
     "davclient.js": "git@github.com:evert/davclient.js.git",
-    "es6-promise": "^3.2.1"
+    "es6-promise": "^3.2.1",
+    "ical.js": "^1.2.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,7 @@
     "requirejs": "2.2.0",
     "text": "^2.0.14",
     "underscore": "~1.8.3",
-    "davclient.js": "git@github.com:evert/davclient.js.git",
+    "davclient.js": "https://github.com/evert/davclient.js.git",
     "es6-promise": "^3.2.1",
     "ical.js": "^1.2.1"
   }

--- a/css/mail.css
+++ b/css/mail.css
@@ -663,7 +663,8 @@ input.submit-message,
 	max-height: 120px;
 }
 .attachment-save-to-cloud,
-.attachment-download {
+.attachment-download,
+.attachment-import {
 	position: absolute;
 	height: 32px;
 	width: 32px;
@@ -674,6 +675,9 @@ input.submit-message,
 }
 .attachment-download {
 	right: 41px;
+}
+.attachment-import {
+	right: 79px;
 }
 /* show icon + text for Download all button
 	as well as when there is only one attachment */

--- a/css/mail.css
+++ b/css/mail.css
@@ -697,7 +697,7 @@ input.submit-message,
 }
 .attachment-name {
 	display: inline-block;
-	width: calc(100% - 110px);
+	width: calc(100% - 148px);
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/css/mail.css
+++ b/css/mail.css
@@ -680,12 +680,11 @@ input.submit-message,
 	right: 79px;
 }
 .attachment-import-popover {
-	right: -17px;
+	right: 42px;
 	top: 56px;
 }
 .attachment-import-popover::after {
-	left: 30px;
-	right: initial;
+	right: 32px;
 }
 /* show icon + text for Download all button
 	as well as when there is only one attachment */

--- a/css/mail.css
+++ b/css/mail.css
@@ -679,6 +679,14 @@ input.submit-message,
 .attachment-import {
 	right: 79px;
 }
+.attachment-import-popover {
+	right: -17px;
+	top: 56px;
+}
+.attachment-import-popover::after {
+	left: 30px;
+	right: initial;
+}
 /* show icon + text for Download all button
 	as well as when there is only one attachment */
 .attachments-save-to-cloud,

--- a/js/app.js
+++ b/js/app.js
@@ -22,6 +22,9 @@
 define(function(require) {
 	'use strict';
 
+	// Enable ES6 promise polyfill
+	require('es6-promise').polyfill();
+
 	var $ = require('jquery');
 	var Backbone = require('backbone');
 	var Handlebars = require('handlebars');
@@ -39,6 +42,7 @@ define(function(require) {
 	require('controller/messagecontroller');
 	require('service/accountservice');
 	require('service/attachmentservice');
+	require('service/davservice');
 	require('service/folderservice');
 	require('service/messageservice');
 	require('notification');

--- a/js/app.js
+++ b/js/app.js
@@ -81,6 +81,8 @@ define(function(require) {
 	Mail = new Mail();
 
 	Mail.on('start', function() {
+		this.hasDavSupport = $('#has-dav-support').val() === '1';
+
 		this.view = new AppView();
 		Cache.init();
 

--- a/js/models/dav/calendar.js
+++ b/js/models/dav/calendar.js
@@ -1,0 +1,26 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Backbone = require('backbone');
+
+	return Backbone.Model.extend({});
+});

--- a/js/radio.js
+++ b/js/radio.js
@@ -13,22 +13,24 @@ define(function(require) {
 
 	var Radio = require('backbone.radio');
 
-	var uiChannel = Radio.channel('ui');
-	var notificationChannel = Radio.channel('notification');
-	var stateChannel = Radio.channel('state');
 	var accountChannel = Radio.channel('account');
 	var folderChannel = Radio.channel('folder');
+	var davChannel = Radio.channel('dav');
 	var messageChannel = Radio.channel('message');
 	var navigationChannel = Radio.channel('navigation');
+	var notificationChannel = Radio.channel('notification');
+	var stateChannel = Radio.channel('state');
+	var uiChannel = Radio.channel('ui');
 
 	var channels = {
-		ui: uiChannel,
-		notification: notificationChannel,
-		state: stateChannel,
 		account: accountChannel,
+		dav: davChannel,
 		folder: folderChannel,
 		message: messageChannel,
-		navigation: navigationChannel
+		navigation: navigationChannel,
+		notification: notificationChannel,
+		state: stateChannel,
+		ui: uiChannel
 	};
 
 	// Log all events to the console

--- a/js/require_config.js
+++ b/js/require_config.js
@@ -25,12 +25,16 @@
 			domready: 'vendor/domReady/domReady',
 			'es6-promise': 'vendor/es6-promise/es6-promise.min',
 			handlebars: 'vendor/handlebars/handlebars',
+			ical: 'vendor/ical.js/build/ical.min',
 			marionette: 'vendor/backbone.marionette/lib/backbone.marionette',
 			underscore: 'vendor/underscore/underscore',
 			text: 'vendor/text/text'
 			},
 			davclient: {
 				exports: 'dav'
+			},
+			ical: {
+				exports: 'ICAL'
 		}
 	});
 

--- a/js/require_config.js
+++ b/js/require_config.js
@@ -29,12 +29,14 @@
 			marionette: 'vendor/backbone.marionette/lib/backbone.marionette',
 			underscore: 'vendor/underscore/underscore',
 			text: 'vendor/text/text'
-			},
+		},
+		shim: {
 			davclient: {
 				exports: 'dav'
 			},
 			ical: {
 				exports: 'ICAL'
+			}
 		}
 	});
 

--- a/js/require_config.js
+++ b/js/require_config.js
@@ -21,11 +21,16 @@
 			 */
 			backbone: 'vendor/backbone/backbone',
 			'backbone.radio': 'vendor/backbone.radio/build/backbone.radio',
+			davclient: 'vendor/davclient.js/lib/client',
 			domready: 'vendor/domReady/domReady',
+			'es6-promise': 'vendor/es6-promise/es6-promise.min',
 			handlebars: 'vendor/handlebars/handlebars',
 			marionette: 'vendor/backbone.marionette/lib/backbone.marionette',
 			underscore: 'vendor/underscore/underscore',
 			text: 'vendor/text/text'
+			},
+			davclient: {
+				exports: 'dav'
 		}
 	});
 

--- a/js/service/attachmentservice.js
+++ b/js/service/attachmentservice.js
@@ -25,6 +25,7 @@ define(function(require) {
 	var Radio = require('radio');
 
 	Radio.message.reply('save:cloud', saveToFiles);
+	Radio.message.reply('attachment:download', downloadAttachment);
 
 	/**
 	 * @param {Account} account
@@ -60,6 +61,21 @@ define(function(require) {
 		};
 
 		$.ajax(url, options);
+		return defer.promise();
+	}
+
+	function downloadAttachment(url) {
+		var defer = $.Deferred();
+
+		$.ajax(url, {
+			success: function(data) {
+				defer.resolve(data);
+			},
+			error: function() {
+				defer.reject();
+			}
+		});
+
 		return defer.promise();
 	}
 

--- a/js/service/davservice.js
+++ b/js/service/davservice.js
@@ -1,0 +1,108 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var _ = require('underscore');
+	var $ = require('jquery');
+	var Backbone = require('backbone');
+	var dav = require('davclient');
+	var OC = require('OC');
+	var Radio = require('radio');
+	var Calendar = require('models/dav/calendar');
+
+	Radio.dav.reply('calendars', getUserCalendars);
+
+	var client = new dav.Client({
+		baseUrl: OC.linkToRemote('dav/calendars'),
+		xmlNamespaces: {
+			'DAV:': 'd',
+			'urn:ietf:params:xml:ns:caldav': 'c',
+			'http://apple.com/ns/ical/': 'aapl',
+			'http://owncloud.org/ns': 'oc',
+			'http://calendarserver.org/ns/': 'cs'
+		}
+	});
+	var props = [
+		'{DAV:}displayname',
+		'{urn:ietf:params:xml:ns:caldav}calendar-description',
+		'{urn:ietf:params:xml:ns:caldav}calendar-timezone',
+		'{http://apple.com/ns/ical/}calendar-order',
+		'{http://apple.com/ns/ical/}calendar-color',
+		'{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set',
+		'{http://owncloud.org/ns}calendar-enabled',
+		'{DAV:}acl',
+		'{DAV:}owner',
+		'{http://owncloud.org/ns}invite'
+	];
+
+	function getResponseCodeFromHTTPResponse(t) {
+		return parseInt(t.split(' ')[1]);
+	}
+
+	function getCalendarData(properties) {
+		var data = {
+			displayname: properties['{DAV:}displayname'],
+			color: properties['{http://apple.com/ns/ical/}calendar-color'],
+			order: properties['{http://apple.com/ns/ical/}calendar-order'],
+			components: {
+				vevent: false
+			}
+		};
+
+		var components = properties['{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'] || [];
+		for (var i = 0; i < components.length; i++) {
+			var name = components[i].attributes.getNamedItem('name').textContent.toLowerCase();
+			if (data.components.hasOwnProperty(name)) {
+				data.components[name] = true;
+			}
+		}
+
+		return data;
+	}
+
+	function getUserCalendars() {
+		var defer = $.Deferred();
+		var url = OC.linkToRemote('dav/calendars') + '/' + OC.currentUser + '/';
+
+		client.propFind(url, props, 1, {
+			'requesttoken': OC.requestToken
+		}).then(function(data) {
+			var calendars = new Backbone.Collection();
+
+			_.each(data.body, function(cal) {
+				if (cal.propStat.length < 1) {
+					return;
+				}
+				if (getResponseCodeFromHTTPResponse(cal.propStat[0].status) === 200) {
+					var properties = getCalendarData(cal.propStat[0].properties);
+					if (properties && properties.components.vevent) {
+						calendars.push(new Calendar(properties));
+					}
+				}
+			});
+			defer.resolve(calendars);
+		}, function() {
+			defer.reject();
+		});
+
+		return defer.promise();
+	}
+});

--- a/js/templates/calendar.html
+++ b/js/templates/calendar.html
@@ -1,1 +1,1 @@
-<a class="select-calendar" data-calendar-url="some-url">{{displayname}}</a>
+<a class="select-calendar" data-calendar-url="{{url}}">{{displayname}}</a>

--- a/js/templates/calendar.html
+++ b/js/templates/calendar.html
@@ -1,0 +1,1 @@
+<a class="select-calendar" data-calendar-url="some-url">{{displayname}}</a>

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -5,7 +5,9 @@
 <img class="attachment-icon" src="{{mimeUrl}}" />
 <span class="attachment-name" title="{{fileName}} ({{humanFileSize size}})">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
 {{#if isCalendarEvent}}
+{{#if hasDavSupport}}
 <button class="button icon-add attachment-import calendar" title="{{ t 'Import into calendar' }}"></button>
+{{/if}}
 {{/if}}
 <button class="button icon-download attachment-download" title="{{ t 'Download attachment' }}"></button>
 <button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -9,3 +9,4 @@
 {{/if}}
 <button class="button icon-download attachment-download" title="{{ t 'Download attachment' }}"></button>
 <button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>
+<div class="popovermenu bubble attachment-import-popover hidden"></div>

--- a/js/templates/message-attachment.html
+++ b/js/templates/message-attachment.html
@@ -4,5 +4,8 @@
 {{/if}}
 <img class="attachment-icon" src="{{mimeUrl}}" />
 <span class="attachment-name" title="{{fileName}} ({{humanFileSize size}})">{{fileName}} <span class="attachment-size">({{humanFileSize size}})</span></span>
+{{#if isCalendarEvent}}
+<button class="button icon-add attachment-import calendar" title="{{ t 'Import into calendar' }}"></button>
+{{/if}}
 <button class="button icon-download attachment-download" title="{{ t 'Download attachment' }}"></button>
 <button class="icon-folder attachment-save-to-cloud" title="{{ t 'Save to Files' }}"></button>

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -62,6 +62,10 @@ define(function(require) {
 
 			window.addEventListener('resize', this.onWindowResize);
 
+			$(document).on('click', function(e) {
+				Radio.ui.trigger('document:click', e);
+			});
+
 			// TODO: create marionette view and encapsulate events
 			$(document).on('click', '#forward-button', function() {
 				Radio.message.trigger('forward');

--- a/js/views/calendarspopoverview.js
+++ b/js/views/calendarspopoverview.js
@@ -1,0 +1,30 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Marionette = require('marionette');
+	var CalendarView = require('views/calendarview');
+
+	return Marionette.CollectionView.extend({
+		childView: CalendarView,
+		tagName: 'ul'
+	});
+});

--- a/js/views/calendarview.js
+++ b/js/views/calendarview.js
@@ -1,0 +1,31 @@
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var Marionette = require('marionette');
+	var Handlebars = require('handlebars');
+	var CalendarTemplate = require('text!templates/calendar.html');
+
+	return Marionette.ItemView.extend({
+		template: Handlebars.compile(CalendarTemplate),
+		tagName: 'li'
+	});
+});

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -99,12 +99,16 @@ define(function(require) {
 
 			var _this = this;
 			$.when(fetchingCalendars).done(function(calendars) {
-				_this.ui.attachmentImportPopover.removeClass('hidden');
-				var calendarsView = new CalendarsPopoverView({
-					collection: calendars
-				});
-				calendarsView.render();
-				_this.ui.attachmentImportPopover.html(calendarsView.$el);
+				if (calendars.length > 0) {
+					_this.ui.attachmentImportPopover.removeClass('hidden');
+					var calendarsView = new CalendarsPopoverView({
+						collection: calendars
+					});
+					calendarsView.render();
+					_this.ui.attachmentImportPopover.html(calendarsView.$el);
+				} else {
+					Radio.ui.trigger('error:show', t('mail', 'No writable calendars found'));
+				}
 			});
 			$.when(fetchingCalendars).always(function() {
 				_this.ui.importCalendarEventButton

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -44,6 +44,11 @@ define(function(require) {
 			'click @ui.saveToCloudButton': '_onSaveToCloud',
 			'click @ui.importCalendarEventButton': '_onImportCalendarEvent'
 		},
+		templateHelpers: function() {
+			return {
+				hasDavSupport: require('app').hasDavSupport
+			};
+		},
 		initialize: function() {
 			this.listenTo(Radio.ui, 'document:click', this._closeImportPopover);
 		},

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -23,6 +23,7 @@ define(function(require) {
 	var $ = require('jquery');
 	var Handlebars = require('handlebars');
 	var Marionette = require('marionette');
+	var Radio = require('radio');
 	var MessageController = require('controller/messagecontroller');
 	var MessageAttachmentTemplate = require('text!templates/message-attachment.html');
 
@@ -33,11 +34,13 @@ define(function(require) {
 		template: Handlebars.compile(MessageAttachmentTemplate),
 		ui: {
 			'downloadButton': '.attachment-download',
-			'saveToCloudButton': '.attachment-save-to-cloud'
+			'saveToCloudButton': '.attachment-save-to-cloud',
+			'importCalendarEventButton': '.attachment-import.calendar'
 		},
 		events: {
 			'click': '_onDownload',
-			'click @ui.saveToCloudButton': '_onSaveToCloud'
+			'click @ui.saveToCloudButton': '_onSaveToCloud',
+			'click @ui.importCalendarEventButton': '_onImportCalendarEvent'
 		},
 		_onDownload: function(e) {
 			if (!e.isDefaultPrevented()) {
@@ -67,6 +70,30 @@ define(function(require) {
 					.removeClass('icon-loading-small')
 					.prop('disabled', false);
 			});
+		},
+		_onImportCalendarEvent: function(e) {
+			e.preventDefault();
+
+			this.ui.importCalendarEventButton
+				.removeClass('icon-add')
+				.addClass('icon-loading-small');
+
+			var url = this.model.get('downloadUrl');
+			var downloading = Radio.message.request('attachment:download', url);
+
+			var _this = this;
+			$.when(downloading).done(function(data) {
+				console.log(data);
+			});
+			$.when(downloading.fail(function() {
+				Radio.ui.trigger('error:show', t('Error while downloading calendar event'));
+			}));
+			$.when(downloading).always(function() {
+				_this.ui.importCalendarEventButton
+					.removeClass('icon-loading-small')
+					.addClass('icon-add');
+			});
+
 		}
 	});
 

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -397,6 +397,8 @@ class MessagesController extends Controller {
 
 		if ($this->attachmentIsImage($attachment)) {
 			$attachment['isImage'] = true;
+		} else if ($this->attachmentIsCalendarEvent($attachment)) {
+			$attachment['isCalendarEvent'] = true;
 		}
 		return $attachment;
 	}
@@ -405,11 +407,24 @@ class MessagesController extends Controller {
 	 * @param $attachment
 	 *
 	 * Determines if the content of this attachment is an image
+	 *
+	 * @return boolean
 	 */
 	private function attachmentIsImage($attachment) {
-		return in_array($attachment['mime'], array('image/jpeg',
+		return in_array(
+			$attachment['mime'], [
+			'image/jpeg',
 			'image/png',
-			'image/gif'));
+			'image/gif'
+		]);
+	}
+
+	/**
+	 * @param type $attachment
+	 * @return boolean
+	 */
+	private function attachmentIsCalendarEvent($attachment) {
+		return $attachment['mime'] === 'text/calendar';
 	}
 
 	/**

--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -77,11 +77,14 @@ class PageController extends Controller {
 	 * @return TemplateResponse renders the index page
 	 */
 	public function index() {
+		$coreVersion = $this->config->getSystemValue('version', '0.0.0');
+		$hasDavSupport = (int) version_compare($coreVersion, '9.0.0', '>=');
 		// TODO: remove DEBUG constant check once minimum oc
 		// core version >= 8.2, see https://github.com/owncloud/core/pull/18510
 		$response = new TemplateResponse($this->appName, 'index', [
 			'debug' => (defined('DEBUG') && DEBUG) || $this->config->getSystemValue('debug', false),
 			'app-version' => $this->config->getAppValue('mail', 'installed_version'),
+			'has-dav-support' => $hasDavSupport,
 		]);
 
 		// set csp rules for ownCloud 8.1

--- a/templates/index.php
+++ b/templates/index.php
@@ -40,6 +40,7 @@ if ($_['debug']) {
 ?>
 
 <input type="hidden" id="config-installed-version" value="<?php p($_['app-version']); ?>">
+<input type="hidden" id="has-dav-support" value="<?php p($_['has-dav-support']); ?>">
 
 <div id="user-displayname"
      style="display: none"><?php p(\OCP\User::getDisplayName(\OCP\User::getUser())); ?></div>

--- a/tests/controller/pagecontrollertest.php
+++ b/tests/controller/pagecontrollertest.php
@@ -48,7 +48,11 @@ class PageControllerTest extends TestCase {
 	}
 
 	public function testIndex() {
-		$this->config->expects($this->once())
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('version', '0.0.0')
+			->will($this->returnValue('8.2.0'));
+		$this->config->expects($this->at(1))
 			->method('getSystemValue')
 			->with('debug', false)
 			->will($this->returnValue(true));
@@ -59,7 +63,8 @@ class PageControllerTest extends TestCase {
 
 		$expected = new TemplateResponse($this->appName, 'index', [
 			'debug' => true,
-			'app-version' => '1.2.3'
+			'app-version' => '1.2.3',
+			'has-dav-support' => 0,
 		]);
 		// set csp rules for ownCloud 8.1
 		if (class_exists('OCP\AppFramework\Http\ContentSecurityPolicy')) {


### PR DESCRIPTION
fixes: https://github.com/owncloud/mail/issues/79

TODO:
- [x] show import button
- [x] download attachment file
- [x] select calendar
- [x] push ics content to the dav endpoint
- [x] show import button only if caldav is enabled/available
- [x] add ES6 promise poly fill
- [x] list only writable calendars

BUGS:
- [x] fix attachment text width if the import button is shown
- [x] popover position
- [x] some .ics file imports fail ``HTTP/1.1 400 Every VEVENT in this object must have identical UIDs``

FUTURE IDEAS
- Show a preview of the calendar data