### PR TITLE
show error when sending a message fails

### DIFF
--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -208,8 +208,8 @@ define(function(require) {
 
 				defer.resolve(data);
 			},
-			error: function() {
-				defer.reject();
+			error: function(xhr) {
+				defer.reject(xhr);
 			},
 			data: {
 				to: message.to,


### PR DESCRIPTION
The jqXHR object was not passed into the promise error callback, hence there was a js error and no error notification was shown.