### PR TITLE
Dont break lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Bring back menu toggle button for mobile
   [#1483](https://github.com/owncloud/mail/pull/1483) @ChristophWurst
+- Don't send messages in flowed text format
+  [#1482](https://github.com/owncloud/mail/pull/1482) @ChristophWurst
 
 ## 0.4.4 – 2016-05-06
 

--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -208,8 +208,8 @@ define(function(require) {
 
 				defer.resolve(data);
 			},
-			error: function() {
-				defer.reject();
+			error: function(xhr) {
+				defer.reject(xhr);
 			},
 			data: {
 				to: message.to,

--- a/lib/account.php
+++ b/lib/account.php
@@ -190,7 +190,7 @@ class Account implements IAccount {
 
 		// Send the message
 		$transport = $this->createTransport();
-		$mail->send($transport);
+		$mail->send($transport, false, false);
 
 		// Save the message in the sent folder
 		$sentFolder = $this->getSentFolder();


### PR DESCRIPTION
Finally, this pesky bug is fixed. I really feel stupid now thinkig about how many hours it took me to discover this tiny little flag ``@param boolean $flowed  Send message in flowed text format.``. For some reason I overlooked that in previous debugging sessions… :disappointed: 

- [x] works for the sent message
- [x] works for the saved message
- [x] works for drafts

@jancborchardt @Gomez @tahaalibra @Scheirle @nicokaiser please test

fixes #1151