### PR TITLE
fetch UIDs and DATEs of all messages and do the pagination client side

### DIFF
--- a/lib/mailbox.php
+++ b/lib/mailbox.php
@@ -114,7 +114,6 @@ class Mailbox implements IMailBox {
 		$q = new Horde_Imap_Client_Fetch_Query();
 		$q->uid();
 		$q->imapDate();
-		// FIXME: $q->headers('DATE', ['DATE']); could be a better option than the INTERNALDATE
 
 		$result = $this->conn->fetch($this->mailBox, $q);
 		$uidMap = [];
@@ -132,7 +131,7 @@ class Mailbox implements IMailBox {
 	}
 
 	public function getMessages($from = 0, $count = 2, $filter = '') {
-		if (is_null($filter) || $filter === '') {
+		if (!$this->conn->capability->query('SORT') && (is_null($filter) || $filter === '')) {
 			$ids = $this->getFetchIds($from, $count);
 		} else {
 			$ids = $this->getSearchIds($from, $count, $filter);


### PR DESCRIPTION
Inspired by @DeepDiver1975's PR https://github.com/owncloud/mail/pull/747 I debugged the message fetching code and found out none of the IMAP servers I use have SORT capabilities. This means horde will do the sort client-side. While that's alright, looking at horde_imap.log I observed that way too much information is queried for sorting. It appears the full envelope data is fetched for sorting by date, which is useless and performance heavy.

This PR is a experiment where the sorting is done client-side by fetching message UIDs and DATEs, slicing the result and fetching the full info of that slice only.

# Benchmark
I compared fetching the unified inbox with three accounts (two on my hoster, one is gmail).

Current master: ~2050ms
This branch: ~1550ms

Considering that ~500ms are needed for an OC request without querying the a IMAP server (tested with PageController::index), the speedup on my setup is about 32%. It will differ on other systems, depending on the server configuration and the mailbox size.

~~*If* a server supports SORT, this strategy *could* be slower than what horde is doing, but I don't have any server available to test this with.~~ It is slower, see comment below