### PR TITLE
traverse folders correctly when searching by folder id

### DIFF
--- a/js/models/account.js
+++ b/js/models/account.js
@@ -27,6 +27,41 @@ define(function(require) {
 		initialize: function() {
 			this.set('folders', new FolderCollection(this.get('folders')));
 		},
+		_getFolderByIdRecursively: function(folder, folderId) {
+			if (!folder) {
+				return null;
+			}
+
+			if (folder.get('id') === folderId) {
+				return folder;
+			}
+
+			var subFolders = folder.get('folders');
+			if (!subFolders) {
+				return null;
+			}
+			for (var i = 0; i < subFolders.length; i++) {
+				var subFolder = this._getFolderByIdRecursively(subFolders.at(i), folderId);
+				if (subFolder) {
+					return subFolder;
+				}
+			}
+
+			return null;
+		},
+		getFolderById: function(folderId) {
+			var folders = this.get('folders');
+			if (!folders) {
+				return null;
+			}
+			for (var i = 0; i < folders.length; i++) {
+				var result = this._getFolderByIdRecursively(folders.at(i), folderId);
+				if (result) {
+					return result;
+				}
+			}
+			return null;
+		},
 		toJSON: function() {
 			var data = Backbone.Model.prototype.toJSON.call(this);
 			if (data.folders && data.folders.toJSON) {

--- a/js/routecontroller.js
+++ b/js/routecontroller.js
@@ -102,13 +102,15 @@ define(function(require) {
 			var account = this.accounts.get(accountId);
 			if (_.isUndefined(account)) {
 				// Unknown account id -> redirect
+				Radio.ui.trigger('error:show', t('mail', 'Invalid account'));
 				_this.default();
 				return;
 			}
 
-			var folder = account.get('folders').get(folderId);
+			var folder = account.getFolderById(folderId);
 			if (_.isUndefined(folder)) {
 				folder = account.get('folders').at(0);
+				Radio.ui.trigger('error:show', t('mail', 'Invalid folder'));
 				this._navigate('accounts/' + accountId + '/folders/' + folder.get('id'));
 			}
 			FolderController.showFolder(account, folder, noSelect);

--- a/js/views/composer.js
+++ b/js/views/composer.js
@@ -306,7 +306,7 @@ define(function(require) {
 
 			if (this.isReply()) {
 				options.messageId = this.messageId;
-				options.folder = this.account.get('folders').get(this.folderId);
+				options.folder = this.account.getFolderById(this.folderId);
 			}
 
 			var sendingMessage = Radio.message.request('send', this.account, this.getMessage(), options);
@@ -376,7 +376,7 @@ define(function(require) {
 			// send the mail
 			var _this = this;
 			var savingDraft = Radio.message.request('draft', this.account, this.getMessage(), {
-				folder: this.account.get('folders').get(this.folderId),
+				folder: this.account.getFolderById(this.folderId),
 				messageId: this.messageId,
 				draftUID: this.draftUID
 			});


### PR DESCRIPTION
The folder data structure is a tree, hence we need to traverse down all hierarchies when doing a search by id.

Note: one could optimize the algorithm by decoding the folder id and guessing the path. I'll leave that for the Mail 10.0 release :hear_no_evil: 

fixes https://github.com/owncloud/mail/issues/1503

@tahaalibra @Gomez @DeepDiver1975 @clementhk @Scheirle review please