### PR TITLE
update grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "bower": "^1.5.2",
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "requirejs": "^2.1.20"
   }
 }


### PR DESCRIPTION
replaces #1528 

Note that I had to update my local npm with ``npm install -g npm`` to get rid of an dependency error related to the package ``fsevents``.

cc @enoch85 