### PR TITLE
open first mailbox when clicking the account's email address

### DIFF
--- a/js/views/account.js
+++ b/js/views/account.js
@@ -102,7 +102,9 @@ define(function(require) {
 		onClick: function(e) {
 			e.preventDefault();
 			if (this.model.get('folders').length > 0) {
-				Radio.navigation.trigger('folder', this.model.get('accountId'), this.model.get('folders').first().get('id'));
+				var accountId = this.model.get('accountId');
+				var folderId = this.model.get('folders').first().get('id');
+				Radio.navigation.trigger('folder', accountId, folderId);
 			}
 		},
 		onShow: function() {

--- a/js/views/account.js
+++ b/js/views/account.js
@@ -40,9 +40,11 @@ define(function(require) {
 		events: {
 			'click .account-toggle-collapse': 'toggleCollapse',
 			'click .app-navigation-entry-utils-menu-button button': 'toggleMenu',
-			'click @ui.deleteButton': 'onDelete'
+			'click @ui.deleteButton': 'onDelete',
+			'click @ui.email': 'onClick'
 		},
 		ui: {
+			'email': '.mail-account-email',
 			'menu': 'div.app-navigation-entry-menu',
 			'deleteButton': 'button[class^="icon-delete"]'
 		},
@@ -96,6 +98,12 @@ define(function(require) {
 					OC.Notification.show(t('mail', 'Error while deleting account.'));
 				}
 			});
+		},
+		onClick: function(e) {
+			e.preventDefault();
+			if (this.model.get('folders').length > 0) {
+				Radio.navigation.trigger('folder', this.model.get('accountId'), this.model.get('folders').first().get('id'));
+			}
 		},
 		onShow: function() {
 			this.listenTo(Radio.ui, 'document:click', function(event) {


### PR DESCRIPTION
While switching between different account's inboxes, I found myself clicking on the account name instead of the 'inbox' mailbox. Hence, I thought we could load the first mailbox of the account in that situation, which most likely is the inbox of that account.

@jancborchardt @skjnldsv what do you think?

Not sure if we should also change the cursor accordingly.