### PR TITLE
remove obsolete folder reset event + event handler

### DIFF
--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -32,7 +32,6 @@ define(function(require) {
 	function loadFolders(account) {
 		var fetchingFolders = FolderService.getFolderEntities(account);
 
-		Radio.ui.trigger('messagesview:messages:reset');
 		$('#app-navigation').addClass('icon-loading');
 
 		$.when(fetchingFolders).fail(function() {
@@ -61,7 +60,6 @@ define(function(require) {
 		// Set folder active
 		Radio.folder.trigger('setactive', account, folder);
 		Radio.ui.trigger('content:loading');
-		Radio.ui.trigger('messagesview:messages:reset');
 
 		$('#load-new-mail-messages').hide();
 		$('#load-more-mail-messages').hide();

--- a/js/views/messages.js
+++ b/js/views/messages.js
@@ -49,7 +49,6 @@ define(function(require) {
 				return _this.collection;
 			});
 			this.listenTo(Radio.ui, 'messagesview:messages:update', this.loadNew);
-			this.listenTo(Radio.ui, 'messagesview:messages:reset', this.reset);
 			this.listenTo(Radio.ui, 'messagesview:messages:add', this.addMessages);
 			this.listenTo(Radio.ui, 'messagesview:messageflag:set', this.setMessageFlag);
 			this.listenTo(Radio.ui, 'messagesview:filter', this.filterCurrentMailbox);
@@ -193,11 +192,6 @@ define(function(require) {
 			message.each(function(msg) {
 				_this.collection.add(msg);
 			});
-		},
-		reset: function() {
-			this.collection.reset();
-
-			$('#messages-loading').fadeIn();
 		}
 	});
 });


### PR DESCRIPTION
This is simply obsolete as we're now storing the list of messages in the folder model, which is used for the folder content view. Hence, there is no need to reset the collection explicitly (it's reset when (re)loading the folder anyway).

please review @tahaalibra @Gomez