### PR TITLE
use underscore to debounce search filters; do not re-search the same …

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -5,21 +5,25 @@
  * later. See the COPYING file.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @copyright Christoph Wurst 2015
+ * @copyright Christoph Wurst 2015, 2016
  */
 
 define(function(require) {
 	'use strict';
 
+	var _ = require('underscore');
 	var Radio = require('radio');
-	var timeoutID = null;
+	var lastQuery = '';
+
+	var debouncedFilter = _.debounce(function debouncedFilterFn(query) {
+		Radio.ui.trigger('messagesview:filter', query);
+	}, 1000);
 
 	function filter(query) {
-		window.clearTimeout(timeoutID);
-		timeoutID = window.setTimeout(function() {
-			Radio.ui.trigger('messagesview:filter', query);
-		}, 500);
-		$('#searchresults').hide();
+		if (query !== lastQuery) {
+			lastQuery = query;
+			debouncedFilter(query);
+		}
 	}
 
 	return {


### PR DESCRIPTION
…term

This fixes three small problems:

1. the message list was reloaded whenever one hit the ESC key (the search was cleared and an empty string is passed into the filter function)
2. the debounce is now handled by underscore instead of our own js fu
3. the debounce timeout was increased as it was way to small for non-hackers (people don't type that fast)