### PR TITLE
use 'mail' instead of 'Mail' for bower to prevent warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Mail",
+  "name": "mail",
   "version": "0.5.3",
   "description": "ownCloud Mail App",
   "main": "mail.js",


### PR DESCRIPTION
Fixes ```bower                     invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes```