### PR TITLE
Enhanced keyboard event handling + new shortcuts

### DIFF
--- a/js/radio.js
+++ b/js/radio.js
@@ -11,27 +11,25 @@
 define(function(require) {
 	'use strict';
 
+	var _ = require('underscore');
 	var Radio = require('backbone.radio');
 
-	var accountChannel = Radio.channel('account');
-	var folderChannel = Radio.channel('folder');
-	var davChannel = Radio.channel('dav');
-	var messageChannel = Radio.channel('message');
-	var navigationChannel = Radio.channel('navigation');
-	var notificationChannel = Radio.channel('notification');
-	var stateChannel = Radio.channel('state');
-	var uiChannel = Radio.channel('ui');
+	var channelNames = [
+		'account',
+		'folder',
+		'dav',
+		'message',
+		'navigation',
+		'notification',
+		'state',
+		'ui',
+		'keyboard'
+	];
 
-	var channels = {
-		account: accountChannel,
-		dav: davChannel,
-		folder: folderChannel,
-		message: messageChannel,
-		navigation: navigationChannel,
-		notification: notificationChannel,
-		state: stateChannel,
-		ui: uiChannel
-	};
+	var channels = {};
+	_.each(channelNames, function(channelName) {
+		channels[channelName] = Radio.channel(channelName);
+	});
 
 	return channels;
 });

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -116,23 +116,12 @@ define(function(require) {
 		},
 		onKeyUp: function(e) {
 			// Define which objects to check for the event properties.
-			// (Window object provides fallback for IE8 and lower.)
-			e = e || window.e;
 			var key = e.keyCode || e.which;
-			// If the client is currently viewing a message:
-			if (require('state').currentMessageId) {
-				if (key === 46) {
-					// If delete key is pressed:
-					// If not composing a reply
-					// and message list is visible (not being in a settings dialog)
-					// and if searchbox is not focused
-					if (!$('.to, .cc, .message-body').is(':focus') &&
-						$('#mail-messages').is(':visible') &&
-						!$('#searchbox').is(':focus')) {
-						// Mimic a client clicking the delete button for the currently active message.
-						$('.mail-message-summary.active .icon-delete.action.delete').click();
-					}
-				}
+
+			// Trigger the event only if no input or textarea is focused
+			if ($('input:focus').length === 0
+				&& $('textarea:focus').length === 0) {
+				Radio.keyboard.trigger('keyup', key);
 			}
 		},
 		onWindowResize: function() {

--- a/js/views/app.js
+++ b/js/views/app.js
@@ -119,9 +119,9 @@ define(function(require) {
 			var key = e.keyCode || e.which;
 
 			// Trigger the event only if no input or textarea is focused
-			if ($('input:focus').length === 0
-				&& $('textarea:focus').length === 0) {
-				Radio.keyboard.trigger('keyup', key);
+			if ($('input:focus').length === 0 &&
+				$('textarea:focus').length === 0) {
+				Radio.keyboard.trigger('keyup', e, key);
 			}
 		},
 		onWindowResize: function() {

--- a/js/views/foldercontent.js
+++ b/js/views/foldercontent.js
@@ -55,6 +55,7 @@ define(function(require) {
 			this.listenTo(Radio.ui, 'message:show', this.onShowMessage);
 			this.listenTo(Radio.ui, 'composer:show', this.onShowComposer);
 			this.listenTo(Radio.ui, 'composer:leave', this.onComposerLeave);
+			this.listenTo(Radio.keyboard, 'keyup', this.onKeyUp);
 
 			// TODO: check whether this code is still needed
 			this.listenTo(Radio.ui, 'composer:events:undelegate', function() {
@@ -149,6 +150,12 @@ define(function(require) {
 		},
 		onMessageLoading: function() {
 			this.message.show(new LoadingView());
+		},
+		onKeyUp: function(key) {
+			if (key === 46) {
+				// Mimic a client clicking the delete button for the currently active message.
+				$('.mail-message-summary.active .icon-delete.action.delete').click();
+			}
 		}
 	});
 });

--- a/js/views/foldercontent.js
+++ b/js/views/foldercontent.js
@@ -152,9 +152,22 @@ define(function(require) {
 			this.message.show(new LoadingView());
 		},
 		onKeyUp: function(key) {
-			if (key === 46) {
-				// Mimic a client clicking the delete button for the currently active message.
-				$('.mail-message-summary.active .icon-delete.action.delete').click();
+			console.log(key);
+			switch (key) {
+				case 46:
+					// Mimic a client clicking the delete button for the currently active message.
+					$('.mail-message-summary.active .icon-delete.action.delete').
+						click();
+					break;
+				case 74:
+					// 'j' -> next message
+					Radio.message.trigger('messagesview:message:next');
+					console.log('j');
+					break;
+				case 75:
+					// 'k' -> previous message
+					Radio.message.trigger('messagesview:message:prev');
+					break;
 			}
 		}
 	});

--- a/js/views/foldercontent.js
+++ b/js/views/foldercontent.js
@@ -151,21 +151,23 @@ define(function(require) {
 		onMessageLoading: function() {
 			this.message.show(new LoadingView());
 		},
-		onKeyUp: function(key) {
-			console.log(key);
+		onKeyUp: function(event, key) {
 			switch (key) {
 				case 46:
 					// Mimic a client clicking the delete button for the currently active message.
 					$('.mail-message-summary.active .icon-delete.action.delete').
 						click();
 					break;
+				case 39:
 				case 74:
-					// 'j' -> next message
+					// right arrow or 'j' -> next message
+					event.preventDefault();
 					Radio.message.trigger('messagesview:message:next');
-					console.log('j');
 					break;
+				case 37:
 				case 75:
-					// 'k' -> previous message
+					// left arrow or 'k' -> previous message
+					event.preventDefault();
 					Radio.message.trigger('messagesview:message:prev');
 					break;
 			}

--- a/js/views/messages.js
+++ b/js/views/messages.js
@@ -54,6 +54,8 @@ define(function(require) {
 			this.listenTo(Radio.ui, 'messagesview:filter', this.filterCurrentMailbox);
 			this.listenTo(Radio.ui, 'messagesview:filter:clear', this.clearFilter);
 			this.listenTo(Radio.ui, 'messagesview:message:setactive', this.setActiveMessage);
+			this.listenTo(Radio.message, 'messagesview:message:next', this.selectNextMessage);
+			this.listenTo(Radio.message, 'messagesview:message:prev', this.selectPreviousMessage);
 		},
 		onShow: function() {
 			this.$scrollContainer = this.$el.parent();
@@ -103,6 +105,54 @@ define(function(require) {
 			require('state').currentMessageId = messageId;
 			require('state').folderView.updateTitle();
 
+		},
+		selectNextMessage: function() {
+			if (this.currentMessageId === null) {
+				return;
+			}
+
+			var message = this.collection.get(this.currentMessageId);
+			if (message === null) {
+				return;
+			}
+
+			if (this.collection.indexOf(message) === (this.collection.length - 1)) {
+				// Last message, nothing to do
+				return;
+			}
+
+			var nextMessage = this.collection.at(this.collection.indexOf(message) + 1);
+			if (nextMessage) {
+				var account = require('state').currentAccount;
+				var folder = require('state').currentFolder;
+				Radio.message.trigger('load', account, folder, nextMessage, {
+					force: true
+				});
+			}
+		},
+		selectPreviousMessage: function() {
+			if (this.currentMessageId === null) {
+				return;
+			}
+
+			var message = this.collection.get(this.currentMessageId);
+			if (message === null) {
+				return;
+			}
+
+			if (this.collection.indexOf(message) === 0) {
+				// First message, nothing to do
+				return;
+			}
+
+			var previousMessage = this.collection.at(this.collection.indexOf(message) - 1);
+			if (previousMessage) {
+				var account = require('state').currentAccount;
+				var folder = require('state').currentFolder;
+				Radio.message.trigger('load', account, folder, previousMessage, {
+					force: true
+				});
+			}
 		},
 		loadNew: function() {
 			if (!require('state').currentAccount) {


### PR DESCRIPTION
This enhances/replaces the previous error-prone keyboard event handling and adds support for 'j', 'k', arrow left/right navigation of messages.

Note that I chose left/right error intentionally as up/down confuses FF and should be used to scroll in long messages or the messages list.

partially fixes https://github.com/owncloud/mail/issues/160