### PR TITLE
Create default account automatically

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -67,10 +67,6 @@ class Application extends App {
 		/* @var $defaultAccountManager \OCA\Mail\Service\DefaultAccount\DefaultAccountManager */
 		$defaultAccountManager = $container->query('\OCA\Mail\Service\DefaultAccount\DefaultAccountManager');
 
-		if (!$defaultAccountManager->defaultConfigAvailable()) {
-			return;
-		}
-
 		$defaultAccountManager->saveLoginPassword($password);
 	}
 

--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -25,6 +25,7 @@
 namespace OCA\Mail\Controller;
 
 use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Service\DefaultAccount\DefaultAccountManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -34,6 +35,11 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class PageController extends Controller {
+
+	/**
+	 * @var DefaultAccountManager
+	 */
+	private $defaultAccountManager;
 
 	/**
 	 * @var MailAccountMapper
@@ -62,11 +68,14 @@ class PageController extends Controller {
 	 * @param IConfig $config
 	 * @param $UserId
 	 */
-	public function __construct($appName, IRequest $request, MailAccountMapper $mailAccountMapper, IURLGenerator $urlGenerator, IConfig $config, $UserId) {
+	public function __construct($appName, IRequest $request,
+		MailAccountMapper $mailAccountMapper, IURLGenerator $urlGenerator,
+		IConfig $config, DefaultAccountManager $defaultAccountManager, $UserId) {
 		parent::__construct($appName, $request);
 		$this->mailAccountMapper = $mailAccountMapper;
 		$this->urlGenerator = $urlGenerator;
 		$this->config = $config;
+		$this->defaultAccountManager = $defaultAccountManager;
 		$this->currentUserId = $UserId;
 	}
 
@@ -77,7 +86,7 @@ class PageController extends Controller {
 	 * @return TemplateResponse renders the index page
 	 */
 	public function index() {
-
+		$this->defaultAccountManager->createOrUpdateDefaultAccount();
 
 		$coreVersion = $this->config->getSystemValue('version', '0.0.0');
 		$hasDavSupport = (int) version_compare($coreVersion, '9.0.0', '>=');

--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -77,6 +77,8 @@ class PageController extends Controller {
 	 * @return TemplateResponse renders the index page
 	 */
 	public function index() {
+
+
 		$coreVersion = $this->config->getSystemValue('version', '0.0.0');
 		$hasDavSupport = (int) version_compare($coreVersion, '9.0.0', '>=');
 		// TODO: remove DEBUG constant check once minimum oc

--- a/lib/db/mailaccountmapper.php
+++ b/lib/db/mailaccountmapper.php
@@ -62,6 +62,16 @@ class MailAccountMapper extends Mapper {
 		return $this->findEntities($sql, $params);
 	}
 
+	public function findByEmail($email, $userId) {
+		$sql = 'SELECT * FROM ' . $this->getTableName() . ' WHERE user_id = ? and email = ?';
+		$params = [
+			$userId,
+			$email,
+		];
+
+		return $this->findEntities($sql, $params);
+	}
+
 	/**
 	 * Saves an User Account into the database
 	 * @param MailAccount $account

--- a/lib/service/defaultaccount/config.php
+++ b/lib/service/defaultaccount/config.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Service\DefaultAccount;
+
+use OCP\IUser;
+
+class Config {
+
+	private $data;
+
+	/**
+	 * @param array $data
+	 */
+	public function __construct($data) {
+		$this->data = $data;
+	}
+
+	/**
+	 * @param IUser $user
+	 * @return string
+	 */
+	public function buildEmail(IUser $user) {
+		return $this->buildUserEmail($this->data['email'], $user);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getImapHost() {
+		return $this->data['imapHost'];
+	}
+
+	/**
+	 * @return string|int
+	 */
+	public function getImapPort() {
+		return $this->data['imapPort'];
+	}
+
+	/**
+	 * @return string
+	 */
+	public function buildImapUser(IUser $user) {
+		if (isset($this->data['imapUser'])) {
+			return $this->buildUserEmail($this->data['imapUser'], $user);
+		}
+		return $this->buildEmail($user);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getImapSslMode() {
+		return $this->data['imapSslMode'];
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSmtpHost() {
+		return $this->data['smtpHost'];
+	}
+
+	/**
+	 * @return string|int
+	 */
+	public function getSmtpPort() {
+		return $this->data['smtpPort'];
+	}
+
+	/**
+	 * @param IUser $user
+	 * @return string
+	 */
+	public function buildSmtpUser(IUser $user) {
+		if (isset($this->data['smtpUser'])) {
+			return $this->buildUserEmail($this->data['smtpUser'], $user);
+		}
+		return $this->buildEmail($user);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSmtpSslMode() {
+		return $this->data['smtpSslMode'];
+	}
+
+	/**
+	 * Replace %USERID% and %EMAIL% to allow special configurations
+	 *
+	 * @param string $original
+	 * @param IUser $user
+	 * @return string
+	 */
+	private function buildUserEmail($original, IUser $user) {
+		$original = str_replace('%USERID%', $user->getUID(), $original);
+		if (!is_null($user->getEMailAddress())) {
+			$original = str_replace('%EMAIL%', $user->getEMailAddress(), $original);
+		}
+
+		return $original;
+	}
+
+}

--- a/lib/service/defaultaccount/defaultaccountmanager.php
+++ b/lib/service/defaultaccount/defaultaccountmanager.php
@@ -69,7 +69,7 @@ class DefaultAccountManager {
 	}
 
 	/**
-	 * @return array
+	 * @return Config|null
 	 */
 	private function getConfig() {
 		$config = $this->config->getSystemValue('app.mail.accounts.default', null);

--- a/lib/service/defaultaccount/defaultaccountmanager.php
+++ b/lib/service/defaultaccount/defaultaccountmanager.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * ownCloud - Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Service\DefaultAccount;
+
+use OCA\Mail\Service\Logger;
+use OCP\IConfig;
+use OCP\ISession;
+
+class DefaultAccountManager {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var ISession */
+	private $session;
+
+	/** @var Logger */
+	private $logger;
+
+	/**
+	 * @param IConfig $config
+	 * @param ISession $session
+	 * @param Logger $logger
+	 */
+	public function __construct(IConfig $config, ISession $session, Logger $logger) {
+		$this->config = $config;
+		$this->session = $session;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Check whether the admin configured default account settings for creating
+	 * a default account
+	 *
+	 * @return boolean
+	 */
+	public function defaultConfigAvailable() {
+		return !is_null($this->getConfig());
+	}
+
+	/**
+	 * @return array
+	 */
+	private function getConfig() {
+		$config = $this->config->getSystemValue('app.mail.accounts.default', null);
+		if (is_null($config)) {
+			$this->logger->debug('no default config found');
+			return null;
+		} else {
+			$this->logger->debug('default config to create a default account found');
+			// TODO: check if config is complete
+			return $config;
+		}
+	}
+
+	/**
+	 * Save the login password to the session to create a default account in a
+	 * sub-sequent request
+	 *
+	 * @param string $password
+	 */
+	public function saveLoginPassword($password) {
+		$this->session->set('mail_default_account_password', $password);
+	}
+
+}

--- a/lib/service/defaultaccount/defaultaccountmanager.php
+++ b/lib/service/defaultaccount/defaultaccountmanager.php
@@ -48,16 +48,6 @@ class DefaultAccountManager {
 	}
 
 	/**
-	 * Check whether the admin configured default account settings for creating
-	 * a default account
-	 *
-	 * @return boolean
-	 */
-	public function defaultConfigAvailable() {
-		return !is_null($this->getConfig());
-	}
-
-	/**
 	 * @return array
 	 */
 	private function getConfig() {

--- a/lib/service/defaultaccount/defaultaccountmanager.php
+++ b/lib/service/defaultaccount/defaultaccountmanager.php
@@ -21,9 +21,14 @@
 
 namespace OCA\Mail\Service\DefaultAccount;
 
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Service\Logger;
 use OCP\IConfig;
 use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\Security\ICrypto;
 
 class DefaultAccountManager {
 
@@ -36,15 +41,31 @@ class DefaultAccountManager {
 	/** @var Logger */
 	private $logger;
 
+	/** @var MailAccountMapper */
+	private $mapper;
+
+	/** @var IUserSession */
+	private $userSession;
+
+	/** @var ICrypto */
+	private $crypto;
+
 	/**
 	 * @param IConfig $config
 	 * @param ISession $session
 	 * @param Logger $logger
+	 * @param MailAccountMapper $mapper
+	 * @param IUserSession $userSession
+	 * @param ICrypto $crypto
 	 */
-	public function __construct(IConfig $config, ISession $session, Logger $logger) {
+	public function __construct(IConfig $config, ISession $session, Logger $logger,
+		MailAccountMapper $mapper, IUserSession $userSession, ICrypto $crypto) {
 		$this->config = $config;
 		$this->session = $session;
 		$this->logger = $logger;
+		$this->mapper = $mapper;
+		$this->userSession = $userSession;
+		$this->crypto = $crypto;
 	}
 
 	/**
@@ -58,7 +79,7 @@ class DefaultAccountManager {
 		} else {
 			$this->logger->debug('default config to create a default account found');
 			// TODO: check if config is complete
-			return $config;
+			return new Config($config);
 		}
 	}
 
@@ -70,6 +91,79 @@ class DefaultAccountManager {
 	 */
 	public function saveLoginPassword($password) {
 		$this->session->set('mail_default_account_password', $password);
+	}
+
+	public function createOrUpdateDefaultAccount() {
+		$config = $this->getConfig();
+		if (is_null($config)) {
+			return;
+		}
+
+		$user = $this->userSession->getUser();
+		if (is_null($user)) {
+			return;
+		}
+
+		$accounts = $this->mapper->findByEmail($config->buildEmail($user), $user->getUID());
+		if (empty($accounts)) {
+			$this->createDefaultAccount($user, $config);
+		} else if (count($accounts) === 1) {
+			$this->updateDefaultAccount($accounts[0], $user, $config);
+		} else {
+			$this->logger->debug('unexpected state: more than one account with the default email found for user ' . $user->getUID());
+		}
+	}
+
+	private function createDefaultAccount(IUser $user, Config $config) {
+		if (!$this->session->exists('mail_default_account_password')) {
+			return;
+		}
+		$this->logger->info('creating default account for user ' . $user->getUID());
+		$password = $this->crypto->encrypt($this->session->get('mail_default_account_password'));
+
+		$account = new MailAccount();
+		$account->setUserId($user->getUID());
+		$account->setEmail($config->buildEmail($user));
+		$account->setName($user->getDisplayName());
+
+		$account->setInboundUser($config->buildImapUser($user));
+		$account->setInboundHost($config->getImapHost());
+		$account->setInboundPort($config->getImapPort());
+		$account->setInboundSslMode($config->getImapSslMode());
+		$account->setInboundPassword($password);
+
+		$account->setOutboundUser($config->buildSmtpUser($user));
+		$account->setOutboundHost($config->getSmtpHost());
+		$account->setOutboundPort($config->getSmtpPort());
+		$account->setOutboundSslMode($config->getSmtpSslMode());
+		$account->setOutboundPassword($password);
+
+		$this->mapper->insert($account);
+	}
+
+	/**
+	 * @todo update imap/smtp config if it changed
+	 *
+	 * @param MailAccount $account
+	 * @param IUser $user
+	 * @param Config $config
+	 */
+	private function updateDefaultAccount(MailAccount $account) {
+		$password = $this->crypto->encrypt($this->session->get('mail_default_account_password'));
+		$needsUpdate = false;
+
+		if ($account->getInboundPassword() !== $password) {
+			$account->setInboundPassword($password);
+			$needsUpdate = true;
+		}
+		if ($account->getOutboundPassword() !== $password) {
+			$account->setOutboundPassword($password);
+			$needsUpdate = true;
+		}
+
+		if ($needsUpdate) {
+			$this->mapper->update($account);
+		}
 	}
 
 }

--- a/tests/controller/pagecontrollertest.php
+++ b/tests/controller/pagecontrollertest.php
@@ -31,6 +31,7 @@ class PageControllerTest extends TestCase {
 	private $mailAccountMapper;
 	private $urlGenerator;
 	private $config;
+	private $defaultAccountManager;
 	private $controller;
 
 	protected function setUp() {
@@ -44,10 +45,17 @@ class PageControllerTest extends TestCase {
 			->getMock();
 		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
 		$this->config = $this->getMock('OCP\IConfig');
-		$this->controller = new PageController($this->appName, $this->request, $this->mailAccountMapper, $this->urlGenerator, $this->config, $this->userId);
+		$this->defaultAccountManager = $this->getMockBuilder('OCA\Mail\Service\DefaultAccount\DefaultAccountManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->controller = new PageController($this->appName, $this->request, $this->mailAccountMapper,
+			$this->urlGenerator, $this->config, $this->defaultAccountManager, $this->userId);
 	}
 
 	public function testIndex() {
+		$this->defaultAccountManager->expects($this->once())
+			->method('createOrUpdateDefaultAccount');
+
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
 			->with('version', '0.0.0')


### PR DESCRIPTION
fixes #166 

TODO:
- [x] save login password to session if config is available
- [x] create a default account if it does not exist
- [x] update the account password if it changed
- [ ] add unit tests
- [ ] find someone who tests this with LDAP
- [ ] document how to configure the default account