### PR TITLE
Update "Resetting the app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Connect to your database and run the following commands (`oc_` is the default ta
 ```sql
 DELETE FROM oc_appconfig WHERE appid = 'mail';
 DROP TABLE oc_mail_accounts;
+DROP TABLE oc_mail_collected_addresses;
 ```
 
 Go to ownCloud Mail in the browser and run this from the developer console to clear the cache:


### PR DESCRIPTION
I followed the instructions to reset the mail app. When re-enabling the app, I got an error message "Table oc_mail_collected_addresses already exists". For a clean reinstall, it has to be dropped, too.