### PR TITLE
fix messages pagination

### DIFF
--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -87,7 +87,9 @@ define(function(require) {
 						require('cache').addMessageList(account, folder, messages);
 					}
 					var collection = folder.get('messages');
-					collection.reset();
+					if (options.replace) {
+						collection.reset();
+					}
 					_.each(messages, function(msg) {
 						collection.add(msg);
 					});

--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -157,14 +157,12 @@ define(function(require) {
 			}
 		},
 		showFolderContent: function(account, folder) {
-			if (this.activeContent !== ContentType.FOLDER_CONTENT) {
-				this.activeContent = ContentType.FOLDER_CONTENT;
+			this.activeContent = ContentType.FOLDER_CONTENT;
 
-				this.content.show(new FolderContentView({
-					account: account,
-					folder: folder
-				}));
-			}
+			this.content.show(new FolderContentView({
+				account: account,
+				folder: folder
+			}));
 		},
 		showContentLoading: function() {
 			if (this.activeContent !== ContentType.LOADING) {

--- a/js/views/messagesview.js
+++ b/js/views/messagesview.js
@@ -36,6 +36,7 @@ define(function(require) {
 		template: Handlebars.compile(MessageListTemplate),
 		currentMessageId: null,
 		loadingMore: false,
+		reloaded: false,
 		filterCriteria: null,
 		initialize: function() {
 			var _this = this;
@@ -158,6 +159,10 @@ define(function(require) {
 			this.loadMessages(false);
 		},
 		onScroll: function() {
+			if (this.reloaded) {
+				this.reloaded = false;
+				return;
+			}
 			if (this.loadingMore === true) {
 				// Ignore events until loading has finished
 				return;
@@ -233,7 +238,10 @@ define(function(require) {
 						{ queue: false, duration: 'slow' }
 					);
 				$('#load-more-mail-messages').removeClass('icon-loading-small');
-				_this.loadingMessages = false;
+				_this.loadingMore = false;
+				// Reload scrolls the list to the top, hence a unwanted
+				// scroll event is fired, which we want to ignore
+				_this.reloaded = reload;
 			});
 		},
 		addMessages: function(message) {


### PR DESCRIPTION
fixes the following bugs:
- pagination works again (next messages are added and the old ones are not removed)
- when reloading the list, some browsers scroll to the top (e.g. FF), where we now discard the first scroll event to prevent double reloading

@jancborchardt @Gomez @owncloud/mail 