### PR TITLE
use session storage instead of local storage

### DIFF
--- a/js/cache.js
+++ b/js/cache.js
@@ -13,7 +13,7 @@ define(function(require) {
 
 	var _ = require('underscore');
 	var $ = require('jquery');
-	var storage = $.localStorage;
+	var storage = $.sessionStorage;
 	var Account = require('models/account');
 
 	var MessageCache = {


### PR DESCRIPTION
Motivation for switching to this shorter-lived storage:
* we store sensitive information in the browser storage, which lives forever if you local storage
* if the cache is old (1d old or older) chances are high it's worthless as the messages in your folders changed already and the cached ones will be deleted anyway
* cache only speeds up page refreshes, so it doesn't really help if our AJAX calls are slow
* if we built better data structures on the client side, we don't have to cache stuff. we can simply built up a data structure of accounts, folders and messages and use the data that has already been loaded before

@LukasReschke @jancborchardt @owncloud/mail please review and tell me what you think. Closing a tab or closing the browser will clear the storage, but I could not really notice the interface loading slower.