### PR TITLE
Load accounts with index page

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -93,8 +93,6 @@ define(function(require) {
 		this.setUpSearch();
 
 		$.when(AccountController.loadAccounts()).done(function(accounts) {
-			$('#app-navigation').removeClass('icon-loading');
-
 			// Start fetching messages in background
 			require('background').messageFetcher.start();
 

--- a/js/controller/accountcontroller.js
+++ b/js/controller/accountcontroller.js
@@ -39,6 +39,7 @@ define(function(require) {
 				Radio.navigation.trigger('setup');
 			} else {
 				var loadingAccounts = accounts.map(function(account) {
+					require('state').folderView.collection.add(account);
 					return FolderController.loadFolder(account);
 				});
 				$.when.apply($, loadingAccounts).done(function() {

--- a/js/controller/accountcontroller.js
+++ b/js/controller/accountcontroller.js
@@ -44,8 +44,7 @@ define(function(require) {
 				Radio.ui.trigger('sidebar:accounts');
 			} else {
 				var loadingAccounts = accounts.map(function(account) {
-					require('state').accounts.add(account);
-					return FolderController.loadFolder(account);
+					return FolderController.loadAccountFolders(account);
 				});
 				$.when.apply($, loadingAccounts).done(function() {
 					defer.resolve(accounts);

--- a/js/controller/accountcontroller.js
+++ b/js/controller/accountcontroller.js
@@ -39,7 +39,7 @@ define(function(require) {
 				Radio.navigation.trigger('setup');
 			} else {
 				var loadingAccounts = accounts.map(function(account) {
-					require('state').folderView.collection.add(account);
+					require('state').accounts.add(account);
 					return FolderController.loadFolder(account);
 				});
 				$.when.apply($, loadingAccounts).done(function() {

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -153,7 +153,7 @@ define(function(require) {
 	}
 
 	return {
-		loadFolder: loadFolders,
+		loadAccountFolders: loadFolders,
 		showFolder: showFolder,
 		searchFolder: searchFolder
 	};

--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -32,8 +32,6 @@ define(function(require) {
 	function loadFolders(account) {
 		var fetchingFolders = FolderService.getFolderEntities(account);
 
-		$('#app-navigation').addClass('icon-loading');
-
 		$.when(fetchingFolders).fail(function() {
 			Radio.ui.trigger('error:show', t('mail', 'Error while loading the selected account.'));
 		});

--- a/js/service/accountservice.js
+++ b/js/service/accountservice.js
@@ -45,16 +45,31 @@ define(function(require) {
 
 	function getAccountEntities() {
 		var defer = $.Deferred();
+		var $serialized = $('#serialized-accounts');
+		var accounts = require('state').accounts;
 
-		require('state').accounts.fetch({
-			success: function(accounts) {
-				require('cache').cleanUp(accounts);
-				defer.resolve(accounts);
-			},
-			error: function() {
-				defer.reject();
+		if ($serialized.val() !== '') {
+			var serialized = $serialized.val();
+			var serialzedAccounts = JSON.parse(atob(serialized));
+
+			accounts.reset();
+			for (var i = 0; i < serialzedAccounts.length; i++) {
+				accounts.add(serialzedAccounts[i]);
 			}
-		});
+			defer.resolve(accounts);
+
+			$serialized.val('');
+		} else {
+			accounts.fetch({
+				success: function(accounts) {
+					require('cache').cleanUp(accounts);
+					defer.resolve(accounts);
+				},
+				error: function() {
+					defer.reject();
+				}
+			});
+		}
 
 		return defer.promise();
 	}

--- a/js/service/folderservice.js
+++ b/js/service/folderservice.js
@@ -37,15 +37,13 @@ define(function(require) {
 					account.set(prop, data[prop]);
 				}
 			}
-
-			require('state').folderView.collection.add(account);
 			defer.resolve(account.get('folders'));
 		});
 
 		promise.fail(function() {
 			defer.reject();
 		});
-		// TODO: handle account fetching error
+
 		return defer.promise();
 	}
 

--- a/js/templates/account.html
+++ b/js/templates/account.html
@@ -1,7 +1,7 @@
-{{#if email}}
-<div class="mail-account-color" style="background-color: {{accountColor email}}"></div>
+{{#if emailAddress}}
+<div class="mail-account-color" style="background-color: {{accountColor emailAddress}}"></div>
 {{/if}}
-<h2 class="mail-account-email" title="{{email}}">{{email}}</h2>
+<h2 class="mail-account-email" title="{{emailAddress}}">{{emailAddress}}</h2>
 
 {{#if hasMenu}}
 <div class="app-navigation-entry-utils">
@@ -24,5 +24,7 @@
 <ul id="mail_folders" class="mail_folders with-icon" data-account_id="{{id}}">
 </ul>
 {{#unless isUnifiedInbox}}
+{{#if hasFolders}}
 <span class="account-toggle-collapse">{{toggleCollapseMessage}}</span>
+{{/if}}
 {{/unless}}

--- a/js/templates/newmessage.html
+++ b/js/templates/newmessage.html
@@ -1,5 +1,4 @@
 <input type="button"
        id="mail_new_message"
        class="icon-add"
-       value="{{ t 'New message' }}"
-       style="display: none">
+       value="{{ t 'New message' }}">

--- a/js/views/account.js
+++ b/js/views/account.js
@@ -11,8 +11,8 @@
 define(function(require) {
 	'use strict';
 
-	var Backbone = require('backbone');
 	var Handlebars = require('handlebars');
+	var Marionette = require('marionette');
 	var OC = require('OC');
 	var Radio = require('radio');
 	var FolderView = require('views/folder');
@@ -24,7 +24,7 @@ define(function(require) {
 		'drafts'
 	]);
 
-	return Backbone.Marionette.CompositeView.extend({
+	return Marionette.CompositeView.extend({
 		collection: null,
 		model: null,
 		template: Handlebars.compile(AccountTemplate),
@@ -33,7 +33,8 @@ define(function(require) {
 			return {
 				isUnifiedInbox: this.model.get('accountId') === -1,
 				toggleCollapseMessage: toggleCollapseMessage,
-				hasMenu: this.model.get('accountId') !== -1
+				hasMenu: this.model.get('accountId') !== -1,
+				hasFolders: this.collection.length > 0
 			};
 		},
 		collapsed: true,

--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -110,8 +110,9 @@ define(function(require) {
 			this.navigation.settings.show(new SettingsView());
 
 			// setup folder view
-			this.accountsView = new NavigationAccountsView();
-			require('state').folderView = this.accountsView;
+			this.accountsView = new NavigationAccountsView({
+				collection: require('state').accounts
+			});
 			this.navigation.accounts.show(this.accountsView);
 		},
 		onDocumentClick: function(event) {

--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -210,7 +210,7 @@ define(function(require) {
 		setSearchQuery: function(val) {
 			val = val || '';
 			$('#searchbox').val(val);
-		}
+		},
 		showSidebarLoading: function() {
 			$('#app-navigation').addClass('icon-loading');
 			this.navigation.accounts.reset();

--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -58,6 +58,8 @@ define(function(require) {
 			this.listenTo(Radio.ui, 'title:update', this.updateTitle);
 			this.listenTo(Radio.ui, 'accountsettings:show', this.showAccountSettings);
 			this.listenTo(Radio.ui, 'search:set', this.setSearchQuery);
+			this.listenTo(Radio.ui, 'sidebar:loading', this.showSidebarLoading);
+			this.listenTo(Radio.ui, 'sidebar:accounts', this.showSidebarAccounts);
 
 			// Hide notification favicon when switching back from
 			// another browser tab
@@ -108,12 +110,6 @@ define(function(require) {
 				accounts: require('state').accounts
 			});
 			this.navigation.settings.show(new SettingsView());
-
-			// setup folder view
-			this.accountsView = new NavigationAccountsView({
-				collection: require('state').accounts
-			});
-			this.navigation.accounts.show(this.accountsView);
 		},
 		onDocumentClick: function(event) {
 			Radio.ui.trigger('document:click', event);
@@ -148,7 +144,6 @@ define(function(require) {
 		},
 		showError: function(message) {
 			OC.Notification.showTemporary(message);
-			$('#app-navigation').removeClass('icon-loading');
 			$('#mail_message').removeClass('icon-loading');
 		},
 		showSetup: function() {
@@ -215,6 +210,19 @@ define(function(require) {
 		setSearchQuery: function(val) {
 			val = val || '';
 			$('#searchbox').val(val);
+		}
+		showSidebarLoading: function() {
+			$('#app-navigation').addClass('icon-loading');
+			this.navigation.accounts.reset();
+		},
+		showSidebarAccounts: function() {
+			$('#app-navigation').removeClass('icon-loading');
+			// setup folder view
+			this.navigation.accounts.show(new NavigationAccountsView({
+				collection: require('state').accounts
+			}));
+			// Also show the 'New message' button
+			Radio.ui.trigger('navigation:newmessage:show');
 		}
 	});
 

--- a/js/views/navigation-accounts.js
+++ b/js/views/navigation-accounts.js
@@ -15,7 +15,6 @@ define(function(require) {
 	var $ = require('jquery');
 	var Marionette = require('marionette');
 	var AccountView = require('views/account');
-	var AccountCollection = require('models/accountcollection');
 	var Radio = require('radio');
 
 	/**
@@ -28,8 +27,6 @@ define(function(require) {
 		 * @returns {undefined}
 		 */
 		initialize: function() {
-			this.collection = new AccountCollection();
-
 			this.listenTo(Radio.ui, 'folder:changed', this.onFolderChanged);
 			this.listenTo(Radio.folder, 'setactive', this.setFolderActive);
 		},
@@ -41,7 +38,8 @@ define(function(require) {
 		setFolderActive: function(account, folder) {
 			// disable all other folders for all accounts
 			require('state').accounts.each(function(acnt) {
-				var localAccount = require('state').folderView.collection.get(acnt.get('accountId'));
+				// TODO: useless? accounts.get(acnt.get('accountId')) === acnt ?
+				var localAccount = require('state').accounts.get(acnt.get('accountId'));
 				if (_.isUndefined(localAccount)) {
 					return;
 				}

--- a/js/views/navigation.js
+++ b/js/views/navigation.js
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @copyright Christoph Wurst 2015
+ * @copyright Christoph Wurst 2015, 2016
  */
 
 define(function(require) {
@@ -26,12 +26,9 @@ define(function(require) {
 		initialize: function(options) {
 			this.bindUIElements();
 
-			this.newMessage.show(new NewMessageView({
-				accounts: options.accounts
-			}));
-
 			this.listenTo(Radio.ui, 'navigation:show', this.show);
 			this.listenTo(Radio.ui, 'navigation:hide', this.hide);
+			this.listenTo(Radio.ui, 'navigation:newmessage:show', this.onShowNewMessage);
 		},
 		render: function() {
 			// This view doesn't need rendering
@@ -46,6 +43,12 @@ define(function(require) {
 				this.$el.hide();
 				$('#app-navigation-toggle').css('background-image', 'none');
 			}
+		},
+		onShowNewMessage: function() {
+			console.log(this.options.accounts);
+			this.newMessage.show(new NewMessageView({
+				accounts: this.options.accounts
+			}));
 		}
 	});
 });

--- a/js/views/navigation.js
+++ b/js/views/navigation.js
@@ -45,7 +45,6 @@ define(function(require) {
 			}
 		},
 		onShowNewMessage: function() {
-			console.log(this.options.accounts);
 			this.newMessage.show(new NewMessageView({
 				accounts: this.options.accounts
 			}));

--- a/js/views/navigation.js
+++ b/js/views/navigation.js
@@ -23,7 +23,7 @@ define(function(require) {
 			accounts: '#app-navigation-accounts',
 			settings: '#app-settings-content'
 		},
-		initialize: function(options) {
+		initialize: function() {
 			this.bindUIElements();
 
 			this.listenTo(Radio.ui, 'navigation:show', this.show);

--- a/js/views/newmessage.js
+++ b/js/views/newmessage.js
@@ -38,6 +38,10 @@ define(function(require) {
 			this.accounts = options.accounts;
 			this.listenTo(options.accounts, 'add', this.onAccountsChanged);
 		},
+		onShow: function() {
+			// Set the approriate ui state
+			this.onAccountsChanged();
+		},
 		onAccountsChanged: function() {
 			if (this.accounts.size === 0) {
 				this.ui.input.hide();

--- a/js/views/setup.js
+++ b/js/views/setup.js
@@ -150,8 +150,6 @@ define(function(require) {
 				Radio.ui.trigger('content:loading');
 				// reload accounts
 				$.when(AccountController.loadAccounts()).done(function(accounts) {
-					$('#app-navigation').removeClass('icon-loading');
-
 					// Let's assume there's at least one account after a successful
 					// setup, so let's show the first one (could be the unified inbox)
 					var firstAccount = accounts.first();

--- a/templates/index.php
+++ b/templates/index.php
@@ -40,6 +40,7 @@ if ($_['debug']) {
 ?>
 
 <input type="hidden" id="config-installed-version" value="<?php p($_['app-version']); ?>">
+<input type="hidden" id="serialized-accounts" value="<?php p($_['accounts']); ?>">
 
 <div id="user-displayname"
      style="display: none"><?php p(\OCP\User::getDisplayName(\OCP\User::getUser())); ?></div>

--- a/tests/controller/pagecontrollertest.php
+++ b/tests/controller/pagecontrollertest.php
@@ -32,6 +32,8 @@ class PageControllerTest extends TestCase {
 	private $urlGenerator;
 	private $config;
 	private $controller;
+	private $accountService;
+	private $aliasesService;
 
 	protected function setUp() {
 		parent::setUp();
@@ -39,15 +41,63 @@ class PageControllerTest extends TestCase {
 		$this->appName = 'mail';
 		$this->userId = 'george';
 		$this->request = $this->getMock('\OCP\IRequest');
-		$this->mailAccountMapper = $this->getMockBuilder('OCA\Mail\Db\MailAccountMapper')
-			->disableOriginalConstructor()
-			->getMock();
 		$this->urlGenerator = $this->getMock('OCP\IURLGenerator');
 		$this->config = $this->getMock('OCP\IConfig');
-		$this->controller = new PageController($this->appName, $this->request, $this->mailAccountMapper, $this->urlGenerator, $this->config, $this->userId);
+		$this->accountService = $this->getMockBuilder('OCA\Mail\Service\AccountService')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->aliasesService = $this->getMockBuilder('\OCA\Mail\Service\AliasesService')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->controller = new PageController($this->appName, $this->request,
+			$this->urlGenerator, $this->config, $this->accountService,
+			$this->aliasesService, $this->userId);
 	}
 
 	public function testIndex() {
+		$account1 = $this->getMock('OCA\Mail\Service\IAccount');
+		$account2 = $this->getMock('OCA\Mail\Service\IAccount');
+
+		$this->accountService->expects($this->once())
+			->method('findByUserId')
+			->with($this->userId)
+			->will($this->returnValue([
+				$account1,
+				$account2,
+			]));
+		$account1->expects($this->once())
+			->method('getConfiguration')
+			->will($this->returnValue([
+				'accountId' => 1,
+			]));
+		$account2->expects($this->once())
+			->method('getConfiguration')
+			->will($this->returnValue([
+				'accountId' => 2,
+			]));
+		$this->aliasesService->expects($this->exactly(2))
+			->method('findAll')
+			->will($this->returnValueMap([
+				[1, $this->userId, ['a11', 'a12']],
+				[2, $this->userId, ['a21', 'a22']],
+			]));
+		$accountsJson = [
+			[
+				'accountId' => 1,
+				'aliases' => [
+					'a11',
+					'a12',
+				]
+			],
+			[
+				'accountId' => 2,
+				'aliases' => [
+					'a21',
+					'a22',
+				]
+			],
+		];
+
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('debug', false)
@@ -57,9 +107,11 @@ class PageControllerTest extends TestCase {
 			->with('mail', 'installed_version')
 			->will($this->returnValue('1.2.3'));
 
-		$expected = new TemplateResponse($this->appName, 'index', [
+		$expected = new TemplateResponse($this->appName, 'index',
+			[
 			'debug' => true,
 			'app-version' => '1.2.3',
+			'accounts' => base64_encode(json_encode($accountsJson)),
 		]);
 		// set csp rules for ownCloud 8.1
 		if (class_exists('OCP\AppFramework\Http\ContentSecurityPolicy')) {


### PR DESCRIPTION
* load list of accounts with index page (hidden input, recommended at http://backbonejs.org/#Collection-fetch). This reduces the time needed to load the initial data on page load.
* hide list of accounts/folders until they have finished loading and an error occurred. This also allows users to finally delete/edit accounts that are (temporarily) failing.