### PR TITLE
Fix requirejs for other locations than apps/

### DIFF
--- a/js/require_config.js
+++ b/js/require_config.js
@@ -39,6 +39,10 @@
 			}
 		}
 	});
+	// avoid optimization errors
+	requirejs.config({
+		baseUrl: OC.linkTo('mail', 'js')
+	});
 
 	require([
 		'app',


### PR DESCRIPTION
Fix for https://github.com/owncloud/mail/issues/1163

This will use a dynamic baseUrl for require.js to make the mail app work within other app folders than apps/.
