### PR TITLE
inject prefilled data

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -43,9 +43,9 @@ if ($_['debug']) {
 <input type="hidden" id="serialized-accounts" value="<?php p($_['accounts']); ?>">
 
 <div id="user-displayname"
-     style="display: none"><?php p(\OCP\User::getDisplayName(\OCP\User::getUser())); ?></div>
+     style="display: none"><?php p($_['prefill_displayName']); ?></div>
 <div id="user-email"
-     style="display: none"><?php p(\OCP\Config::getUserValue(\OCP\User::getUser(), 'settings', 'email', '')); ?></div>
+     style="display: none"><?php p($_['prefill_email']); ?></div>
 <div id="app">
 	<div id="app-navigation" class="icon-loading">
 		<div id="mail-new-message-fixed"></div>


### PR DESCRIPTION
Makes the code testable and fixed the following code checker error:
```
Analysing nextcloud/apps/mail/templates/index.php
 4 errors
    line   46: OCP\User::getDisplayName - Method of deprecated class must not be called
    line   46: OCP\User::getUser - Method of deprecated class must not be called
    line   48: OCP\Config - Static method of deprecated class must not be called
    line   48: OCP\User::getUser - Method of deprecated class must not be called
```