### PR TITLE
replace Util::imagePath with OCP\IURLGenerator::imagePath

### DIFF
--- a/lib/service/htmlpurify/transformcssbackground.php
+++ b/lib/service/htmlpurify/transformcssbackground.php
@@ -65,7 +65,7 @@ class TransformCSSBackground extends HTMLPurifier_AttrTransform {
 				strpos($value, 'url(') !== false) {
 				// Replace image URL
 				$value = preg_replace('/url\("?http.*\)/i',
-					'url('.Util::imagePath('mail', 'blocked-image.png').')',
+					'url(' . $this->urlGenerator->imagePath('mail', 'blocked-image.png') . ')',
 					$value);
 				return $name.':'.$value;
 			} else {

--- a/lib/service/htmlpurify/transformimagesrc.php
+++ b/lib/service/htmlpurify/transformimagesrc.php
@@ -63,7 +63,7 @@ class TransformImageSrc extends HTMLPurifier_AttrTransform {
 		if (isset($attr['width']) && isset($attr['height']) &&
 			(int)$attr['width'] < 5 && (int)$attr['height'] < 5){
 			// Replace with a transparent png in case it's important for the layout
-			$attr['src'] = Util::imagePath('mail', 'blocked-image.png');
+			$attr['src'] = $this->urlGenerator->imagePath('mail', 'blocked-image.png');
 			$attr = $this->setDisplayNone($attr);
 			return $attr;
 		}
@@ -72,7 +72,7 @@ class TransformImageSrc extends HTMLPurifier_AttrTransform {
 		$url = $this->parser->parse($attr['src']);
 		if ($url->host === Util::getServerHostName() && $url->path === $this->urlGenerator->linkToRoute('mail.proxy.proxy')) {
 			$attr['data-original-src'] = $attr['src'];
-			$attr['src'] = Util::imagePath('mail', 'blocked-image.png');
+			$attr['src'] = $this->urlGenerator->imagePath('mail', 'blocked-image.png');
 			$attr = $this->setDisplayNone($attr);
 		}
 		return $attr;


### PR DESCRIPTION
Fixes
```
Analysing nextcloud/apps/mail/lib/service/htmlpurify/transformimagesrc.php
 2 errors
    line   66: Util::imagePath - Method of deprecated class must not be called
    line   75: Util::imagePath - Method of deprecated class must not be called
```
and
```
Analysing nextcloud/apps/mail/lib/service/htmlpurify/transformcssbackground.php
 1 errors
    line   68: Util::imagePath - Method of deprecated class must not be called
```