### PR TITLE
replace Util::linkToRoute with IUrlGenerator::linkToRoute

### DIFF
--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -393,7 +393,7 @@ class MessagesController extends Controller {
 			'messageId' => $messageId,
 			'attachmentId' => $attachment['id'],
 		]);
-		$downloadUrl = OC::$server->getURLGenerator()->getAbsoluteURL($downloadUrl);
+		$downloadUrl = $this->urlGenerator->getAbsoluteURL($downloadUrl);
 		$attachment['downloadUrl'] = $downloadUrl;
 		$attachment['mimeUrl'] = $this->mimeTypeDetector->mimeTypeIcon($attachment['mime']);
 
@@ -436,12 +436,12 @@ class MessagesController extends Controller {
 	 * @return string
 	 */
 	private function buildHtmlBodyUrl($accountId, $folderId, $messageId) {
-		$htmlBodyUrl = OC::$server->getURLGenerator()->linkToRoute('mail.messages.getHtmlBody', [
+		$htmlBodyUrl = $this->urlGenerator->linkToRoute('mail.messages.getHtmlBody', [
 			'accountId' => $accountId,
 			'folderId' => $folderId,
 			'messageId' => $messageId,
 		]);
-		return OC::$server->getURLGenerator()->getAbsoluteURL($htmlBodyUrl);
+		return $this->urlGenerator->getAbsoluteURL($htmlBodyUrl);
 	}
 
 	/**

--- a/lib/controller/messagescontroller.php
+++ b/lib/controller/messagescontroller.php
@@ -47,9 +47,11 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\Util;
 
 class MessagesController extends Controller {
+
 
 	/** @var AccountService */
 	private $accountService;
@@ -72,6 +74,9 @@ class MessagesController extends Controller {
 	/** @var IL10N */
 	private $l10n;
 
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
 	/** @var IAccount[] */
 	private $accounts = [];
 
@@ -85,6 +90,7 @@ class MessagesController extends Controller {
 	 * @param Logger $logger
 	 * @param IL10N $l10n
 	 * @param IMimeTypeDetector $mimeTypeDetector
+	 * @param IURLGenerator $urlGenerator
 	 */
 	public function __construct($appName,
 								IRequest $request,
@@ -94,7 +100,8 @@ class MessagesController extends Controller {
 								ContactsIntegration $contactsIntegration,
 								Logger $logger,
 								IL10N $l10n,
-								IMimeTypeDetector $mimeTypeDetector) {
+								IMimeTypeDetector $mimeTypeDetector,
+								IURLGenerator $urlGenerator) {
 		parent::__construct($appName, $request);
 		$this->accountService = $accountService;
 		$this->currentUserId = $UserId;
@@ -103,6 +110,7 @@ class MessagesController extends Controller {
 		$this->logger = $logger;
 		$this->l10n = $l10n;
 		$this->mimeTypeDetector = $mimeTypeDetector;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -379,7 +387,7 @@ class MessagesController extends Controller {
 	 * @return callable
 	 */
 	private function enrichDownloadUrl($accountId, $folderId, $messageId, $attachment) {
-		$downloadUrl = Util::linkToRoute('mail.messages.downloadAttachment', [
+		$downloadUrl = $this->urlGenerator->linkToRoute('mail.messages.downloadAttachment', [
 			'accountId' => $accountId,
 			'folderId' => $folderId,
 			'messageId' => $messageId,

--- a/tests/controller/messagescontrollertest.php
+++ b/tests/controller/messagescontrollertest.php
@@ -47,14 +47,13 @@ class MessagesControllerTest extends \Test\TestCase {
 	private $message;
 	private $attachment;
 	private $mimeTypeDetector;
+	private $urlGenerator;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->appName = 'mail';
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->request = $this->getMockBuilder('\OCP\IRequest')->getMock();
 		$this->accountService = $this->getMockBuilder('\OCA\Mail\Service\AccountService')
 			->disableOriginalConstructor()
 			->getMock();
@@ -71,10 +70,9 @@ class MessagesControllerTest extends \Test\TestCase {
 		$this->logger = $this->getMockBuilder('\OCA\Mail\Service\Logger')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->mimeTypeDetector = $this->getMock('OCP\Files\IMimeTypeDetector');
+		$this->l10n = $this->getMockBuilder('\OCP\IL10N')->getMock();
+		$this->mimeTypeDetector = $this->getMockBuilder('OCP\Files\IMimeTypeDetector')->getMock();
+		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')->getMock();
 
 		$this->controller = new MessagesController(
 			$this->appName,
@@ -85,7 +83,8 @@ class MessagesControllerTest extends \Test\TestCase {
 			$this->contactIntegration,
 			$this->logger,
 			$this->l10n,
-			$this->mimeTypeDetector);
+			$this->mimeTypeDetector,
+			$this->urlGenerator);
 
 		$this->account = $this->getMockBuilder('\OCA\Mail\Account')
 			->disableOriginalConstructor()


### PR DESCRIPTION
@owncloud/mail easy to review :-)

Fixes 
```
Analysing nextcloud/apps/mail/lib/controller/messagescontroller.php
 1 errors
    line  382: Util::linkToRoute - Method of deprecated class must not be called
```