### PR TITLE
delay app start until the page has been fully loaded

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -133,8 +133,10 @@ define(function(require) {
 		})(), 1000);
 	});
 
-	_.delay(function() {
+	$(function() {
+		// Start app when the page is ready
 		Mail.start();
 	});
+
 	return Mail;
 });


### PR DESCRIPTION
fixes https://github.com/owncloud/mail/issues/1622

I don't know why this errror occurs now for so many people, but apparently the script is executed before the full page html has been loaded, therefore the element is not found.

@owncloud/mail @LEDfan @zeugmatis @irgendwie @Draghtnod review/test please.

@Gomez I think we should backport this fix and release it as 0.5.3