### PR TITLE
Language update

### DIFF
--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -37,7 +37,7 @@ OC.L10N.register(
     "Error while deleting message." : "Fout bij verwijderen bericht.",
     "Connecting" : "Verbinden",
     "Connect" : "Verbinden",
-    "Inbox" : "Inbakje",
+    "Inbox" : "Postvak In",
     "Sent" : "Verzonden",
     "Drafts" : "Concepten",
     "Archive" : "Archief",


### PR DESCRIPTION
Inbakje is not a dutch word, inbox is also a correct term for Dutch
