### PR TITLE
Language update

### DIFF
--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -35,7 +35,7 @@
     "Error while deleting message." : "Fout bij verwijderen bericht.",
     "Connecting" : "Verbinden",
     "Connect" : "Verbinden",
-    "Inbox" : "Inbakje",
+    "Inbox" : "Postvak In",
     "Sent" : "Verzonden",
     "Drafts" : "Concepten",
     "Archive" : "Archief",


### PR DESCRIPTION
Inbakje is not a dutch word, inbox is also a correct term for Dutch
